### PR TITLE
Avoid R CMD check notes about {tidyselect} variables

### DIFF
--- a/R/plot_alignment_table.R
+++ b/R/plot_alignment_table.R
@@ -202,7 +202,7 @@ make_annotations_df <- function(data) {
     ymax = c(1.5, 2.5, 3.5)
   )
 
-  annotations <- unique(data %>% pull(technology)) %>%
+  annotations <- unique(data %>% pull("technology")) %>%
     purrr::map_df(~ annotations_tech %>% mutate(technology = .x))
 
   data_portfolio <- data %>%
@@ -213,7 +213,7 @@ make_annotations_df <- function(data) {
       aligned_portfolio_temp = .data$aligned_scen_temp
     ) %>%
     select(
-      c(technology, aligned_scen_temp, entity, aligned_portfolio_temp)
+      c("technology", "aligned_scen_temp", "entity", "aligned_portfolio_temp")
     ) %>%
     distinct()
 

--- a/R/plot_fossil_bars.R
+++ b/R/plot_fossil_bars.R
@@ -79,10 +79,10 @@ check_data_fossil_bars <- function(data, env) {
 check_single_index_per_asset_class <- function(data, column, env) {
   .data <- deparse_1(substitute(data, env = env))
   data <- data %>%
-    filter(entity == "index")
+    filter(.data$entity == "index")
   if (nrow(data) > 0)
     asset_classes <- unique(data$asset_class)
-    
+
     for (asset in asset_classes) {
         data_subset <- data %>%
           filter(.data$asset_class == asset)

--- a/R/plot_scores.R
+++ b/R/plot_scores.R
@@ -23,7 +23,7 @@ plot_scores <- function(data) {
 
   data <- data %>%
     dplyr::inner_join(alignment_scores_values, by = c("score" = "score_symbol")) %>%
-    select(-c(category, score_delta, score_upper)) %>%
+    select(-c("category", "score_delta", "score_upper")) %>%
     mutate(
       score_symbol = .data$score
     )
@@ -55,7 +55,7 @@ plot_scores <- function(data) {
 plot_score_portfolio <- function(data) {
   c_position <- alignment_scores_values %>%
     filter(.data$score_symbol == "C") %>%
-    pull(score_label)
+    pull("score_label")
 
   p <- plot_basic_scorebar() +
     annotate("segment", x = 0.5, xend = 1.5, y = c_position, yend = c_position, size = 1.3) +
@@ -90,7 +90,7 @@ plot_score_sector <- function(data, sector) {
 
   c_position <- alignment_scores_values %>%
     filter(.data$score_symbol == "C") %>%
-    pull(score_label)
+    pull("score_label")
 
   p <- plot_basic_scorebar() +
     annotate(

--- a/R/plot_scores_scorecard.R
+++ b/R/plot_scores_scorecard.R
@@ -155,7 +155,7 @@ get_portfolio_pointer_df <- function(data, asset_class) {
   idx <- which(rev(scores_labels()) == data_asset$score[1])
   portfolio_score <- data_asset %>%
     dplyr::inner_join(alignment_scores_values, by = c("score" = "score_symbol")) %>%
-    pull(score_upper)
+    pull("score_upper")
 
   portfolio_pointer <- tibble::tibble(
     group = replicate(5, "portfolio"),

--- a/R/prep_alignment_table.R
+++ b/R/prep_alignment_table.R
@@ -38,16 +38,16 @@ prep_alignment_table <- function(results_portfolio,
 
     scenarios <- scenario_thresholds %>%
       dplyr::filter(.data$scenario_source == .env$scenario_source) %>%
-      dplyr::pull(scenario)
+      dplyr::pull("scenario")
 
     # get scenarios for relevant thresholds
     scenario_high_ambition <- scenario_thresholds %>%
       dplyr::filter(.data$threshold == "high") %>%
-      dplyr::pull(scenario)
+      dplyr::pull("scenario")
 
     scenario_medium_ambition <- scenario_thresholds %>%
       dplyr::filter(.data$threshold == "mid") %>%
-      dplyr::pull(scenario)
+      dplyr::pull("scenario")
 
     # prepare data for technology alignment calculation
     data_tech_alignment <- data %>%
@@ -80,13 +80,13 @@ prep_alignment_table <- function(results_portfolio,
     # select the relevant variables
     data_out <- data_tech_alignment_color %>%
       dplyr::select(
-        c(ald_sector, technology, asset_class, entity, aligned_scen_temp,
-          plan_carsten, green_or_brown)
+        c("ald_sector", "technology", "asset_class", "entity", "aligned_scen_temp",
+          "plan_carsten", "green_or_brown")
       ) %>%
       dplyr::rename(
-        sector = ald_sector,
-        perc_aum = plan_carsten,
-        green_brown = green_or_brown
+        sector = "ald_sector",
+        perc_aum = "plan_carsten",
+        green_brown = "green_or_brown"
       ) %>%
       filter(.data$asset_class == .env$asset_class)
   }
@@ -118,7 +118,7 @@ wrangle_input_data_alignment_table <- function(data,
       ald_sector = .data$sector_p4b,
       technology = .data$technology_p4b
     ) %>%
-    dplyr::select(-c(sector_p4b, technology_p4b))
+    dplyr::select(-c("sector_p4b", "technology_p4b"))
 
   # Coal, Oil & Gas are mapped to Fossil Fuels sector
   data <- data %>%
@@ -133,9 +133,9 @@ wrangle_input_data_alignment_table <- function(data,
   # Keep only sectors and technologies as defined in the template
   data <- data %>%
     dplyr::filter(
-      ald_sector %in% c("automotive", "fossil_fuels", "power"),
-      !(ald_sector == "automotive" & stringr::str_detect(technology, "_hdv")),
-      !(ald_sector == "power" & technology %in% c("hydrocap", "nuclearcap"))
+      .data$ald_sector %in% c("automotive", "fossil_fuels", "power"),
+      !(.data$ald_sector == "automotive" & stringr::str_detect(.data$technology, "_hdv")),
+      !(.data$ald_sector == "power" & .data$technology %in% c("hydrocap", "nuclearcap"))
     )
 
   return(data)
@@ -174,7 +174,7 @@ calculate_tech_traffic_light <- function(data,
         sum(.data$tech_score) == 1 ~ "1.5-1.8C",
         TRUE ~ ">1.8C"
       ),
-      entity = replace(.data$entity, entity == "this_portfolio", "portfolio")
+      entity = replace(.data$entity, .data$entity == "this_portfolio", "portfolio")
     ) %>%
     dplyr::ungroup() %>%
     dplyr::filter(.data$scenario == .env$scenario_high_ambition)

--- a/R/prep_climate_strategy_scorecard.R
+++ b/R/prep_climate_strategy_scorecard.R
@@ -29,9 +29,9 @@ prep_climate_strategy_scorecard_initiatives <- function(data,
   # prepare data sets
   data <- data %>%
     dplyr::mutate(entity_type = "this_portfolio") %>%
-    dplyr::mutate(yes = sum(climate_initiative, na.rm = TRUE)) %>%
+    dplyr::mutate(yes = sum(.data$climate_initiative, na.rm = TRUE)) %>%
     dplyr::filter(.data$peer_group == .env$peer_group) %>%
-    dplyr::select(c(entity_type, peer_group, yes, name_climate_initiative))
+    dplyr::select(c("entity_type", "peer_group", "yes", "name_climate_initiative"))
 
   data_peers <- data_peers %>%
     dplyr::mutate(
@@ -39,7 +39,7 @@ prep_climate_strategy_scorecard_initiatives <- function(data,
       name_climate_initiative = NA_character_
     ) %>%
     dplyr::filter(.data$peer_group == .env$peer_group) %>%
-    dplyr::select(c(entity_type, peer_group, yes = peers_yes, name_climate_initiative))
+    dplyr::select(c("entity_type", "peer_group", yes = "peers_yes", "name_climate_initiative"))
 
   # combine data sets
   climate_strategy_scorecard_initiatives <- data %>%
@@ -79,18 +79,18 @@ prep_climate_strategy_scorecard_engagement <- function(data,
   data <- data %>%
     dplyr::mutate(entity_type = "this_portfolio") %>%
     dplyr::mutate(
-      yes = dplyr::if_else(engagement == "yes", 1, 0),
-      no = dplyr::if_else(engagement == "no", 1, 0),
-      not_answered = dplyr::if_else(engagement == "not_answered", 1, 0)
+      yes = dplyr::if_else(.data$engagement == "yes", 1, 0),
+      no = dplyr::if_else(.data$engagement == "no", 1, 0),
+      not_answered = dplyr::if_else(.data$engagement == "not_answered", 1, 0)
     ) %>%
     dplyr::filter(.data$peer_group == .env$peer_group) %>%
-    dplyr::select(c(entity_type, peer_group, asset_type, yes, no, not_answered))
+    dplyr::select(c("entity_type", "peer_group", "asset_type", "yes", "no", "not_answered"))
 
   data_peers <- data_peers %>%
     dplyr::mutate(entity_type = "peers") %>%
     dplyr::filter(.data$peer_group == .env$peer_group) %>%
     dplyr::rename_with(~ gsub("peers_", "", .x, fixed = TRUE)) %>%
-    dplyr::select(c(entity_type, peer_group, yes, no, not_answered))
+    dplyr::select(c("entity_type", "peer_group", "yes", "no", "not_answered"))
 
   # combine data sets
   climate_strategy_scorecard_engagement <- data %>%
@@ -130,18 +130,18 @@ prep_climate_strategy_scorecard_voting <- function(data,
   data <- data %>%
     dplyr::mutate(entity_type = "this_portfolio") %>%
     dplyr::mutate(
-      yes = dplyr::if_else(voting_rights == "yes", 1, 0),
-      no = dplyr::if_else(voting_rights == "no", 1, 0),
-      not_answered = dplyr::if_else(voting_rights == "not_answered", 1, 0)
+      yes = dplyr::if_else(.data$voting_rights == "yes", 1, 0),
+      no = dplyr::if_else(.data$voting_rights == "no", 1, 0),
+      not_answered = dplyr::if_else(.data$voting_rights == "not_answered", 1, 0)
     ) %>%
     dplyr::filter(.data$peer_group == .env$peer_group) %>%
-    dplyr::select(c(entity_type, peer_group, asset_type, yes, no, not_answered))
+    dplyr::select(c("entity_type", "peer_group", "asset_type", "yes", "no", "not_answered"))
 
   data_peers <- data_peers %>%
     dplyr::mutate(entity_type = "peers") %>%
     dplyr::filter(.data$peer_group == .env$peer_group) %>%
     dplyr::rename_with(~ gsub("peers_", "", .x, fixed = TRUE)) %>%
-    dplyr::select(c(entity_type, peer_group, yes, no, not_answered))
+    dplyr::select(c("entity_type", "peer_group", "yes", "no", "not_answered"))
 
   # combine data sets
   climate_strategy_scorecard_voting <- data %>%

--- a/R/prep_exposures_scorecard.R
+++ b/R/prep_exposures_scorecard.R
@@ -19,20 +19,20 @@ prep_exposures_scorecard <- function(results_portfolio,
   } else {
     # check input
     check_data_prep_exposures_scorecard(scenario_selected = scenario_selected)
-  
+
     # input data
     data <- results_portfolio
-  
+
     # infer start year
     start_year <- min(data$year, na.rm = TRUE)
-  
+
     # filter data
     data <- data %>%
       dplyr::filter(
-        year == .env$start_year,
+        .data$year == .env$start_year,
         .data$scenario == .env$scenario_selected
       )
-  
+
     # calculate current exposures and wrangle for score card
     data_out <- data %>%
       wrangle_data_exposures_scorecard()
@@ -69,17 +69,17 @@ wrangle_data_exposures_scorecard <- function(data) {
       )
     ) %>%
     dplyr::filter(!is.na(.data$sector_or_tech)) %>%
-    dplyr::select(c(asset_class, sector_or_tech, plan_carsten)) %>%
-    dplyr::rename(exposure_perc_aum = plan_carsten) %>%
-    dplyr::group_by(asset_class, sector_or_tech) %>%
+    dplyr::select(c("asset_class", "sector_or_tech", "plan_carsten")) %>%
+    dplyr::rename(exposure_perc_aum = "plan_carsten") %>%
+    dplyr::group_by(.data$asset_class, .data$sector_or_tech) %>%
     dplyr::summarise(
-      exposure_perc_aum = sum(exposure_perc_aum, na.rm = TRUE),
+      exposure_perc_aum = sum(.data$exposure_perc_aum, na.rm = TRUE),
       .groups = "drop"
     ) %>%
     dplyr::ungroup() %>%
     mutate(
       sector_or_tech = factor(
-        sector_or_tech,
+        .data$sector_or_tech,
         levels = rev(c("coal", "other_fossil_fuels", "fossil_power", "renewables_power"))
       )
     )

--- a/R/prep_exposures_survey.R
+++ b/R/prep_exposures_survey.R
@@ -30,33 +30,33 @@ prep_exposures_survey <- function(results_portfolio,
     # validate inputs
     sector <- match.arg(sector)
     asset_class <- match.arg(asset_class)
-  
+
     check_data_prep_exposures_survey(
       asset_class = asset_class,
       sector = sector
     )
-  
+
     # infer start year
     start_year <- min(results_portfolio$year, na.rm = TRUE)
-  
+
     # pick scenario for filtering (no impact on current exposure)
     scenario_filter <- "1.5C-Unif"
-  
+
     # combine input data
     data <- results_portfolio %>%
       dplyr::bind_rows(peers_results_aggregated)
-  
+
     # calculate current exposures
     data <- data %>%
       dplyr::filter(
-        year == .env$start_year,
+        .data$year == .env$start_year,
         .data$scenario == .env$scenario_filter
       )
-  
+
     # wrangle to expected format
     data <- data %>%
       wrangle_data_exposures_survey()
-  
+
     data_out <- data %>%
       dplyr::filter(
         .data$asset_class == .env$asset_class,
@@ -87,14 +87,14 @@ wrangle_data_exposures_survey <- function(data) {
       technology = .data$technology_p4b,
       entity = replace(.data$entity, .data$entity == "this_portfolio", "portfolio")
     ) %>%
-    dplyr::select(c(asset_class, entity, ald_sector, plan_carsten)) %>%
+    dplyr::select(c("asset_class", "entity", "ald_sector", "plan_carsten")) %>%
     dplyr::rename(
-      sector = ald_sector,
-      exposure_perc_aum = plan_carsten
+      sector = "ald_sector",
+      exposure_perc_aum = "plan_carsten"
     ) %>%
-    dplyr::group_by(asset_class, entity, sector) %>%
+    dplyr::group_by(.data$asset_class, .data$entity, .data$sector) %>%
     dplyr::summarise(
-      exposure_perc_aum = sum(exposure_perc_aum, na.rm = TRUE),
+      exposure_perc_aum = sum(.data$exposure_perc_aum, na.rm = TRUE),
       .groups = "drop"
     ) %>%
     dplyr::ungroup()

--- a/R/prep_fossil_bars.R
+++ b/R/prep_fossil_bars.R
@@ -43,7 +43,7 @@ prep_fossil_bars <- function(results_portfolio,
     # filter combined input data
     data <- data %>%
       dplyr::filter(
-        year == .env$start_year,
+        .data$year == .env$start_year,
         .data$scenario == .env$scenario_selected,
         .data$ald_sector %in% c("Coal", "Oil&Gas")
       )
@@ -56,7 +56,7 @@ prep_fossil_bars <- function(results_portfolio,
 }
 
 check_data_prep_fossil_bars <- function(scenario_selected) {
-  if (!scenario_selected %in% unique(scenario_thresholds$scenario)) {
+  if (!scenario_selected %in% unique(get("scenario_thresholds")$scenario)) {
     stop("Argument scenario_selected does not hold an accepted value.")
   }
   if (length(scenario_selected) != 1) {
@@ -83,17 +83,17 @@ wrangle_data_fossil_bars <- function(data) {
       )
     ) %>%
     dplyr::inner_join(
-      p4i_p4b_sector_technology_mapper,
+      get("p4i_p4b_sector_technology_mapper"),
       by = c("ald_sector" = "sector_p4i", "technology" = "technology_p4i")
     ) %>%
     dplyr::mutate(
       ald_sector = .data$sector_p4b,
       technology = .data$technology_p4b
     ) %>%
-    dplyr::select(-c(sector_p4b, technology_p4b)) %>%
+    dplyr::select(-c("sector_p4b", "technology_p4b")) %>%
     dplyr::select(
-      c(entity, entity_name, entity_type, year, tech = technology,
-      perc_aum = plan_carsten, asset_class)
+      c("entity", "entity_name", "entity_type", "year", tech = "technology",
+      perc_aum = "plan_carsten", "asset_class")
     ) %>%
     dplyr::arrange(.data$asset_class, dplyr::desc(.data$entity_name), .data$tech)
 

--- a/R/prep_green_brown_bars.R
+++ b/R/prep_green_brown_bars.R
@@ -28,7 +28,7 @@ prep_green_brown_bars <- function(results_portfolio,
     # filter data
     data <- data %>%
       dplyr::filter(
-        year == .env$start_year,
+        .data$year == .env$start_year,
         .data$scenario == .env$scenario_selected
       )
 
@@ -42,15 +42,15 @@ prep_green_brown_bars <- function(results_portfolio,
     data_out <- data %>%
       calculate_exposures() %>%
       dplyr::select(
-        c(asset_class, year, tech_type, sector, perc_tech_exposure,
-          perc_sec_exposure)
+        c("asset_class", "year", "tech_type", "sector", "perc_tech_exposure",
+          "perc_sec_exposure")
       )
   }
   data_out
 }
 
 check_data_prep_green_brown_bars <- function(scenario_selected) {
-  if (!scenario_selected %in% unique(scenario_thresholds$scenario)) {
+  if (!scenario_selected %in% unique(get("scenario_thresholds")$scenario)) {
     stop("Argument scenario_selected does not hold an accepted value.")
   }
   if (length(scenario_selected) != 1) {
@@ -68,7 +68,7 @@ map_sectors_and_tech_type <- function(data) {
       ald_sector = .data$sector_p4b,
       technology = .data$technology_p4b
     ) %>%
-    dplyr::select(-c(sector_p4b, technology_p4b)) %>%
+    dplyr::select(-c("sector_p4b", "technology_p4b")) %>%
     dplyr::mutate(
       ald_sector = dplyr::case_when(
         .data$ald_sector == "coal" ~ "fossil_fuels",
@@ -90,8 +90,8 @@ map_sectors_and_tech_type <- function(data) {
 calculate_exposures <- function(data) {
   data <- data %>%
     dplyr::select(
-      c(investor_name, portfolio_name, entity_name, entity_type, entity,
-        asset_class, year, tech_type, ald_sector, plan_carsten)
+      c("investor_name", "portfolio_name", "entity_name", "entity_type", "entity",
+        "asset_class", "year", "tech_type", "ald_sector", "plan_carsten")
     ) %>%
     dplyr::group_by(
       .data$investor_name, .data$portfolio_name,.data$entity_name,
@@ -107,7 +107,7 @@ calculate_exposures <- function(data) {
     ) %>%
     dplyr::mutate(perc_sec_exposure = sum(.data$perc_tech_exposure, na.rm = TRUE)) %>%
     dplyr::ungroup() %>%
-    dplyr::rename(sector = ald_sector) %>%
+    dplyr::rename(sector = "ald_sector") %>%
     dplyr::arrange(
       .data$investor_name, .data$portfolio_name, .data$sector, .data$asset_class,
       .data$tech_type

--- a/R/prep_net_zero_commitments.R
+++ b/R/prep_net_zero_commitments.R
@@ -50,7 +50,7 @@ prep_portfolio_sbti_commitments <- function(total_portfolio,
       net_zero_targets,
       by = c("isin", "factset_entity_id")
     ) %>%
-    dplyr::distinct(investor_name, portfolio_name, factset_entity_id, has_net_zero_commitment) %>%
+    dplyr::distinct("investor_name", "portfolio_name", "factset_entity_id", "has_net_zero_commitment") %>%
     dplyr::group_by(.data$investor_name, .data$portfolio_name) %>%
     dplyr::summarise(
       share_net_zero = sum(.data$has_net_zero_commitment, na.rm = TRUE) / dplyr::n(),

--- a/R/prep_scatter.R
+++ b/R/prep_scatter.R
@@ -26,7 +26,7 @@ prep_scatter <- function(results_portfolio,
 
     scenarios <- scenario_thresholds %>%
       dplyr::filter(.data$scenario_source == .env$scenario_source) %>%
-      dplyr::pull(scenario)
+      dplyr::pull("scenario")
 
     # combine input data
     data <- results_portfolio %>%
@@ -44,7 +44,7 @@ prep_scatter <- function(results_portfolio,
     # calculate current exposures
     data_exposure <- data %>%
       dplyr::filter(
-        year == .env$start_year,
+        .data$year == .env$start_year,
         .data$scenario == .env$scenario_selected
       )
 
@@ -57,7 +57,7 @@ prep_scatter <- function(results_portfolio,
     # calculate tech_type and sector exposures
     data_exposure <- data_exposure %>%
       calculate_exposures() %>%
-      dplyr::filter(tech_type == "green")
+      dplyr::filter(.data$tech_type == "green")
 
     # calculate future alignment scores
 
@@ -91,9 +91,9 @@ prep_scatter <- function(results_portfolio,
         )
       ) %>%
       dplyr::select(
-        c(asset_class, year, perc_tech_exposure, score, entity_name, entity_type)
+        c("asset_class", "year", "perc_tech_exposure", "score", "entity_name", "entity_type")
       ) %>%
-      dplyr::rename(tech_mix_green = perc_tech_exposure) %>%
+      dplyr::rename(tech_mix_green = "perc_tech_exposure") %>%
       dplyr::mutate(
         entity_type = dplyr::if_else(.data$entity_name == "peers_average", "peers_mean", .data$entity_type)
       )

--- a/R/prep_scores.R
+++ b/R/prep_scores.R
@@ -43,7 +43,7 @@ prep_scores <- function(results_portfolio,
 
     scenarios <- scenario_thresholds %>%
       dplyr::filter(.data$scenario_source == .env$scenario_source) %>%
-      dplyr::pull(scenario)
+      dplyr::pull("scenario")
 
     # prepare data for sector aggregation
     data_aggregate_scores <- data %>%
@@ -90,7 +90,7 @@ prep_scores <- function(results_portfolio,
     # combine scores in single data frame
     output_scores <- sector_aggregate_scores %>%
       dplyr::bind_rows(portfolio_aggregate_scores) %>%
-      dplyr::select(-sector_exposure)
+      dplyr::select(-"sector_exposure")
 
     # apply scenario based grades
     data_out <- output_scores %>%
@@ -98,7 +98,7 @@ prep_scores <- function(results_portfolio,
         scenario_thresholds = scenario_thresholds
       ) %>%
       dplyr::select(
-        c(asset_class, scope, entity, sector, score)
+        c("asset_class", "scope", "entity", "sector", "score")
       )
   }
   data_out
@@ -133,7 +133,7 @@ wrangle_input_data_aggregate_scores <- function(data,
       ald_sector = .data$sector_p4b,
       technology = .data$technology_p4b
     ) %>%
-    dplyr::select(-c(sector_p4b, technology_p4b))
+    dplyr::select(-c("sector_p4b", "technology_p4b"))
 
   # Oil & Gas are treated as separate sectors in the aggregate score.
   data <- data %>%
@@ -164,7 +164,7 @@ calculate_technology_alignment <- function(data,
       plan_alloc_wt_tech_prod_t5 = dplyr::last(.data$plan_alloc_wt_tech_prod),
       exposure_t0 = dplyr::first(.data$plan_carsten)
     ) %>%
-    dplyr::select(-c(scen_alloc_wt_tech_prod)) %>%
+    dplyr::select(-c("scen_alloc_wt_tech_prod")) %>%
     dplyr::filter(.data$year == .env$start_year + .env$time_horizon) %>%
     dplyr::mutate(
       tech_trajectory_alignment = dplyr::if_else(
@@ -212,7 +212,7 @@ calculate_sector_aggregate_scores <- function(data) {
       )
     ) %>%
     dplyr::ungroup() %>%
-    dplyr::select(-c(production_change))
+    dplyr::select(-c("production_change"))
 
   # calculate sector score & sector exposure
   data <- data %>%
@@ -299,14 +299,14 @@ calculate_aggregate_scores_with_scenarios <- function(data,
   # add threshold scenarios
   data <- data %>%
     dplyr::select(
-      c(investor_name, portfolio_name, asset_class, scope, entity_name,
-        entity_type, entity, ald_sector, scenario_source, scenario, score)
+      c("investor_name", "portfolio_name", "asset_class", "scope", "entity_name",
+        "entity_type", "entity", "ald_sector", "scenario_source", "scenario", "score")
     ) %>%
     dplyr::inner_join(
       scenario_thresholds,
       by = c("scenario_source", "scenario")
     ) %>%
-    dplyr::select(-c(scenario, scenario_source))
+    dplyr::select(-c("scenario", "scenario_source"))
 
   data <- data %>%
     tidyr::pivot_wider(
@@ -318,7 +318,7 @@ calculate_aggregate_scores_with_scenarios <- function(data,
       names_from = .data$threshold,
       values_from = .data$score
     ) %>%
-    dplyr::rename(sector = ald_sector)
+    dplyr::rename(sector = "ald_sector")
 
   # calculate grades based on scores and scenario thresholds
   data <- data %>%
@@ -336,8 +336,8 @@ calculate_aggregate_scores_with_scenarios <- function(data,
 
   data <- data %>%
     dplyr::select(
-      c(investor_name, portfolio_name, asset_class, scope, entity_name,
-        entity_type, entity, sector, score)
+      c("investor_name", "portfolio_name", "asset_class", "scope", "entity_name",
+        "entity_type", "entity", "sector", "score")
     ) %>%
     dplyr::arrange(
       .data$investor_name, .data$portfolio_name, .data$asset_class, .data$scope,


### PR DESCRIPTION
Follows the current canonical method of avoiding R CMD check notes caused by data masking in {tidyselect} functions.