### PR TITLE
use `.data$` pronoun in `dplyr::distinct()`

### DIFF
--- a/R/prep_net_zero_commitments.R
+++ b/R/prep_net_zero_commitments.R
@@ -50,7 +50,7 @@ prep_portfolio_sbti_commitments <- function(total_portfolio,
       net_zero_targets,
       by = c("isin", "factset_entity_id")
     ) %>%
-    dplyr::distinct("investor_name", "portfolio_name", "factset_entity_id", "has_net_zero_commitment") %>%
+    dplyr::distinct(.data$investor_name, .data$portfolio_name, .data$factset_entity_id, .data$has_net_zero_commitment) %>%
     dplyr::group_by(.data$investor_name, .data$portfolio_name) %>%
     dplyr::summarise(
       share_net_zero = sum(.data$has_net_zero_commitment, na.rm = TRUE) / dplyr::n(),


### PR DESCRIPTION
closes #76 

I made a mistake while doing the {tidyselect}/data-masking cleanup and used the {tidyselect}-in-quotations style in a `dplyr::distinct()` command, whereas I should have used the `.data$` pronoun style