### PR TITLE
Error handling plots

### DIFF
--- a/R/plot_alignment_table.R
+++ b/R/plot_alignment_table.R
@@ -20,54 +20,62 @@
 #'
 #' plot_alignment_table(toy_data_alignment_table %>% filter(asset_class == "equity"))
 plot_alignment_table <- function(data) {
-  stopifnot(is.data.frame(data))
-  if (nrow(data) > 0) {
-    env <- list(data = substitute(data))
-    check_data_alignment_table(data, env = env)
+  tryCatch(
+    {
+      stopifnot(is.data.frame(data))
+      if (nrow(data) > 0) {
+        env <- list(data = substitute(data))
+        check_data_alignment_table(data, env = env)
 
-    size_lim <- c(min(data$perc_aum, na.rm = TRUE), max(data$perc_aum, na.rm = TRUE))
-    size_range <- c(4, 12)
-  
-    if (nrow(data %>% filter(.data$sector == "power")) > 0) {
-      p_power <- plot_alignment_table_sector_stripe(data, "power", size_lim,
-        size_range,
-        ncol = 4
-      )
-    } else {
-      p_power <- patchwork::plot_spacer()
+        size_lim <- c(min(data$perc_aum, na.rm = TRUE), max(data$perc_aum, na.rm = TRUE))
+        size_range <- c(4, 12)
+
+        if (nrow(data %>% filter(.data$sector == "power")) > 0) {
+          p_power <- plot_alignment_table_sector_stripe(data, "power", size_lim,
+                                                        size_range,
+                                                        ncol = 4
+          )
+        } else {
+          p_power <- patchwork::plot_spacer()
+        }
+
+        if (nrow(data %>% filter(.data$sector == "fossil_fuels")) > 0) {
+          p_fossil <- plot_alignment_table_sector_stripe(data, "fossil_fuels", size_lim,
+                                                         size_range,
+                                                         ncol = 3
+          )
+        } else {
+          p_fossil <- patchwork::plot_spacer()
+        }
+
+        if (nrow(data %>% filter(.data$sector == "automotive")) > 0) {
+          p_auto <- plot_alignment_table_sector_stripe(data, "automotive", size_lim,
+                                                       size_range,
+                                                       ncol = 3
+          )
+        } else {
+          p_auto <- patchwork::plot_spacer()
+        }
+
+
+        p_ylabel <- ggplot(data.frame(l = "Aligned scenario temperature", x = 1, y = 1)) +
+          geom_text(aes(x = .data$x, y = .data$y, label = .data$l), angle = 90, size = 7) +
+          theme_void() +
+          coord_cartesian(clip = "off")
+
+        p_tech <- (p_power / p_fossil / p_auto) +
+          plot_layout(guides = "collect")
+
+        p <- p_ylabel + p_tech + plot_layout(widths = c(1, 15))
+      } else {
+        p <- empty_plot_no_data_message()
+      }
+    },
+    error = function (e) {
+      cat("There was an error in plot_alignment_table().\nReturning empty plot object.\n")
+      p <- empty_plot_error_message()
     }
-  
-    if (nrow(data %>% filter(.data$sector == "fossil_fuels")) > 0) {
-      p_fossil <- plot_alignment_table_sector_stripe(data, "fossil_fuels", size_lim,
-        size_range,
-        ncol = 3
-      )
-    } else {
-      p_fossil <- patchwork::plot_spacer()
-    }
-  
-    if (nrow(data %>% filter(.data$sector == "automotive")) > 0) {
-      p_auto <- plot_alignment_table_sector_stripe(data, "automotive", size_lim,
-        size_range,
-        ncol = 3
-      )
-    } else {
-      p_auto <- patchwork::plot_spacer()
-    }
-  
-  
-    p_ylabel <- ggplot(data.frame(l = "Aligned scenario temperature", x = 1, y = 1)) +
-      geom_text(aes(x = .data$x, y = .data$y, label = .data$l), angle = 90, size = 7) +
-      theme_void() +
-      coord_cartesian(clip = "off")
-  
-    p_tech <- (p_power / p_fossil / p_auto) +
-      plot_layout(guides = "collect")
-  
-    p <- p_ylabel + p_tech + plot_layout(widths = c(1, 15))
-  } else {
-    p <- empty_plot_no_data_message()
-  }
+  )
   p
 }
 

--- a/R/plot_diagram.R
+++ b/R/plot_diagram.R
@@ -23,187 +23,195 @@
 #' plot_diagram(toy_data_diagram)
 
 plot_diagram <- function(data = NULL) {
-  env <- list(data = substitute(data))
-  check_data_diagram(data, env)
+  tryCatch(
+    {
+      env <- list(data = substitute(data))
+      check_data_diagram(data, env)
 
-  data_bonds <- data %>%
-    filter(.data$asset_class == "bonds")
+      data_bonds <- data %>%
+        filter(.data$asset_class == "bonds")
 
-  data_equity <- data %>%
-    filter(.data$asset_class == "equity")
+      data_equity <- data %>%
+        filter(.data$asset_class == "equity")
 
-  currency_id <- "CHF"
-  emissions_unit <- "tonnes"
+      currency_id <- "CHF"
+      emissions_unit <- "tonnes"
 
-  ttl_exp_lbl <- paste0(scales::label_comma()(data_equity$exposure_portfolio), " ", currency_id)
+      ttl_exp_lbl <- paste0(scales::label_comma()(data_equity$exposure_portfolio), " ", currency_id)
 
-  eq_exp_lbl <-
-    paste0(
-      scales::percent(data_equity$exposure_asset_class_perc),
-      "\n(",
-      scales::label_comma()(data_equity$exposure_asset_class),
-      " ", currency_id, ")"
-    )
+      eq_exp_lbl <-
+        paste0(
+          scales::percent(data_equity$exposure_asset_class_perc),
+          "\n(",
+          scales::label_comma()(data_equity$exposure_asset_class),
+          " ", currency_id, ")"
+        )
 
-  cb_exp_lbl <-
-    paste0(
-      scales::percent(data_bonds$exposure_asset_class_perc),
-      "\n(",
-      scales::label_comma()(data_bonds$exposure_asset_class),
-      " ", currency_id, ")"
-    )
+      cb_exp_lbl <-
+        paste0(
+          scales::percent(data_bonds$exposure_asset_class_perc),
+          "\n(",
+          scales::label_comma()(data_bonds$exposure_asset_class),
+          " ", currency_id, ")"
+        )
 
-  eq_pacta_exp_lbl <-
-    paste0(
-      scales::percent(data_equity$exposure_pacta_perc_asset_class_exposure),
-      "\n(",
-      scales::label_comma()(data_equity$exposure_pacta),
-      " ", currency_id, ")"
-    )
+      eq_pacta_exp_lbl <-
+        paste0(
+          scales::percent(data_equity$exposure_pacta_perc_asset_class_exposure),
+          "\n(",
+          scales::label_comma()(data_equity$exposure_pacta),
+          " ", currency_id, ")"
+        )
 
-  cb_pacta_exp_lbl <-
-    paste0(
-      scales::percent(data_bonds$exposure_pacta_perc_asset_class_exposure),
-      "\n(",
-      scales::label_comma()(data_bonds$exposure_pacta),
-      " ", currency_id, ")"
-    )
+      cb_pacta_exp_lbl <-
+        paste0(
+          scales::percent(data_bonds$exposure_pacta_perc_asset_class_exposure),
+          "\n(",
+          scales::label_comma()(data_bonds$exposure_pacta),
+          " ", currency_id, ")"
+        )
 
-  eq_emiss_exp_lbl <-
-    paste0(
-      scales::percent(data_equity$emissions_pacta_perc),
-      "\n(",
-      scales::label_comma()(data_equity$emissions_pacta),
-      " ", emissions_unit, ")"
-    )
+      eq_emiss_exp_lbl <-
+        paste0(
+          scales::percent(data_equity$emissions_pacta_perc),
+          "\n(",
+          scales::label_comma()(data_equity$emissions_pacta),
+          " ", emissions_unit, ")"
+        )
 
-  cb_emiss_exp_lbl <-
-    paste0(
-      scales::percent(data_bonds$emissions_pacta_perc),
-      "\n(",
-      scales::label_comma()(data_bonds$emissions_pacta),
-      " ", emissions_unit, ")"
-    )
+      cb_emiss_exp_lbl <-
+        paste0(
+          scales::percent(data_bonds$emissions_pacta_perc),
+          "\n(",
+          scales::label_comma()(data_bonds$emissions_pacta),
+          " ", emissions_unit, ")"
+        )
 
-  box_width <- 15
-  box_height <- 10
-  arrow_x_length <- 10
+      box_width <- 15
+      box_height <- 10
+      arrow_x_length <- 10
 
-  row_mid_y <- 20
-  row_top_y <- 30
-  row_bottom_y <- 10
+      row_mid_y <- 20
+      row_top_y <- 30
+      row_bottom_y <- 10
 
-  col_1_x <- 0
+      col_1_x <- 0
 
-  box_linewidth <- 0.25
-  arrow_linewidth <- 0.15
-  arrow_length_mm <- 2
+      box_linewidth <- 0.25
+      arrow_linewidth <- 0.15
+      arrow_length_mm <- 2
 
-  box_text_offset_x <- box_width / 2
-  box_text_offset_y <- box_height / 2
-  box_label_offset_x <- box_width / 2
-  box_label_offset_y <- box_height + 5
+      box_text_offset_x <- box_width / 2
+      box_text_offset_y <- box_height / 2
+      box_label_offset_x <- box_width / 2
+      box_label_offset_y <- box_height + 5
 
-  col_2_x <- col_1_x + box_width + arrow_x_length
-  col_3_x <- col_2_x + box_width + arrow_x_length
-  col_4_x <- col_3_x + box_width + arrow_x_length
+      col_2_x <- col_1_x + box_width + arrow_x_length
+      col_3_x <- col_2_x + box_width + arrow_x_length
+      col_4_x <- col_3_x + box_width + arrow_x_length
 
-  arrow_label_offset_x <- box_width + (arrow_x_length / 2)
-  arrow_label_offset_y <- row_top_y - row_mid_y + (box_height / 2) - 3
-  arrow_label_angle <- 27
+      arrow_label_offset_x <- box_width + (arrow_x_length / 2)
+      arrow_label_offset_y <- row_top_y - row_mid_y + (box_height / 2) - 3
+      arrow_label_angle <- 27
 
-  ggplot(tibble(x = 0:100, y = 0:100), aes(x = .data$x, y = .data$y)) +
-    theme_void() +
-    scale_y_continuous(limits = c(0, 50)) +
-    # total exposure
-    annotate("text", x = col_1_x + box_label_offset_x, y = row_mid_y + box_label_offset_y, label = "Total Portfolio Exposure", size = 2.5) +
-    geom_rect(xmin = col_1_x, xmax = col_1_x + box_width,
-              ymin = row_mid_y, ymax = row_mid_y + box_height,
-              color = "black", fill = "white", linewidth = box_linewidth) +
-    annotate("text", x = col_1_x + box_text_offset_x, y = row_mid_y + box_text_offset_y, label = ttl_exp_lbl, size = 2.5) +
-    # first segments
-    annotate("text", x = col_1_x + arrow_label_offset_x,
-             y = row_mid_y + arrow_label_offset_y,
-             label = "Listed Equity",
-             size = 2.5, angle = arrow_label_angle) +
-    geom_segment(
-      x = col_1_x + box_width, xend = col_2_x,
-      y = row_mid_y + box_text_offset_y, yend = row_top_y + box_text_offset_y,
-      linewidth = arrow_linewidth, linejoin = "mitre", lineend = "butt",
-      arrow = arrow(length = unit(arrow_length_mm, "mm"), type= "closed")
-    ) +
-    annotate("text", x = col_1_x + arrow_label_offset_x,
-             y = row_mid_y - arrow_label_offset_y + box_height,
-             label = "Corporate Bonds",
-             size = 2.5, angle = -arrow_label_angle) +
-    geom_segment(
-      x = col_1_x + box_width, xend = col_2_x,
-      y = row_mid_y + box_text_offset_y, yend = row_bottom_y + box_text_offset_y,
-      linewidth = arrow_linewidth, linejoin = "mitre", lineend = "butt",
-      arrow = arrow(length = unit(arrow_length_mm, "mm"), type= "closed")
-    ) +
-    # exposure per asset class
-    annotate("text", x = col_2_x + box_label_offset_x, y = row_top_y + box_label_offset_y, label = "Exposure per asset class", size = 2.5) +
-    # equity exposure
-    geom_rect(xmin = col_2_x, xmax = col_2_x + box_width,
-              ymin = row_top_y, ymax = row_top_y + box_height,
-              color = "black", fill = "white", linewidth = box_linewidth) +
-    annotate("text", x = col_2_x + box_text_offset_x, y = row_top_y + box_text_offset_y, label = eq_exp_lbl, size = 2.5) +
-    # bond exposure
-    geom_rect(xmin = col_2_x, xmax = col_2_x + box_width,
-              ymin = row_bottom_y, ymax = row_bottom_y + box_height,
-              color = "black", fill = "white", linewidth = box_linewidth) +
-    annotate("text", x = col_2_x + box_text_offset_x, y = row_bottom_y + box_text_offset_y, label = cb_exp_lbl, size = 2.5) +
-    # second segments
-    geom_segment(
-      x = col_2_x + box_width, xend = col_3_x,
-      y = row_top_y + box_text_offset_y, yend = row_top_y + box_text_offset_y,
-      linewidth = arrow_linewidth, linejoin = "mitre", lineend = "butt",
-      arrow = arrow(length = unit(arrow_length_mm, "mm"), type= "closed")
-    ) +
-    geom_segment(
-      x = col_2_x + box_width, xend = col_3_x,
-      y = row_bottom_y + box_text_offset_y, yend = row_bottom_y + box_text_offset_y,
-      linewidth = arrow_linewidth, linejoin = "mitre", lineend = "butt",
-      arrow = arrow(length = unit(arrow_length_mm, "mm"), type= "closed")
-    ) +
-    # exposure to PACTA sectors per asset class
-    annotate("text", x = col_3_x + box_label_offset_x, y = row_top_y + box_label_offset_y, label = "Exposure covered by PACTA sectors*\n(as % of asset class exposure", size = 2.5) +
-    # equity PACTA exposure
-    geom_rect(xmin = col_3_x, xmax = col_3_x + box_width,
-              ymin = row_top_y, ymax = row_top_y + box_height,
-              color = "black", fill = "white", linewidth = box_linewidth) +
-    annotate("text", x = col_3_x + box_text_offset_x, y = row_top_y + box_text_offset_y, label = eq_pacta_exp_lbl, size = 2.5) +
-    # bond PACTA exposure
-    geom_rect(xmin = col_3_x, xmax = col_3_x + box_width,
-              ymin = row_bottom_y, ymax = row_bottom_y + box_height,
-              color = "black", fill = "white", linewidth = box_linewidth) +
-    annotate("text", x = col_3_x + box_text_offset_x, y = row_bottom_y + box_text_offset_y, label = cb_pacta_exp_lbl, size = 2.5) +
-    # third segments
-    geom_segment(
-      x = col_3_x + box_width, xend = col_4_x,
-      y = row_top_y + box_text_offset_y, yend = row_top_y + box_text_offset_y,
-      linewidth = arrow_linewidth, linejoin = "mitre", lineend = "butt",
-      arrow = arrow(length = unit(arrow_length_mm, "mm"), type= "closed")
-    ) +
-    geom_segment(
-      x = col_3_x + box_width, xend = col_4_x,
-      y = row_bottom_y + box_text_offset_y, yend = row_bottom_y + box_text_offset_y,
-      linewidth = arrow_linewidth, linejoin = "mitre", lineend = "butt",
-      arrow = arrow(length = unit(arrow_length_mm, "mm"), type= "closed")
-    ) +
-    # emissions per asset class
-    annotate("text", x = col_4_x + box_label_offset_x, y = row_top_y + box_label_offset_y, label = "Emissions covered by PACTA sectors*\n(as % of asset class emissions", size = 2.5) +
-    # equity emissions
-    geom_rect(xmin = col_4_x, xmax = col_4_x + box_width,
-              ymin = row_top_y, ymax = row_top_y + box_height,
-              color = "black", fill = "white", linewidth = box_linewidth) +
-    annotate("text", x = col_4_x + box_text_offset_x, y = row_top_y + box_text_offset_y, label = eq_emiss_exp_lbl, size = 2.5) +
-    # bond PACTA exposure
-    geom_rect(xmin = col_4_x, xmax = col_4_x + box_width,
-              ymin = row_bottom_y, ymax = row_bottom_y + box_height,
-              color = "black", fill = "white", linewidth = box_linewidth) +
-    annotate("text", x = col_4_x + box_text_offset_x, y = row_bottom_y + box_text_offset_y, label = cb_emiss_exp_lbl, size = 2.5)
+      ggplot(tibble(x = 0:100, y = 0:100), aes(x = .data$x, y = .data$y)) +
+        theme_void() +
+        scale_y_continuous(limits = c(0, 50)) +
+        # total exposure
+        annotate("text", x = col_1_x + box_label_offset_x, y = row_mid_y + box_label_offset_y, label = "Total Portfolio Exposure", size = 2.5) +
+        geom_rect(xmin = col_1_x, xmax = col_1_x + box_width,
+                  ymin = row_mid_y, ymax = row_mid_y + box_height,
+                  color = "black", fill = "white", linewidth = box_linewidth) +
+        annotate("text", x = col_1_x + box_text_offset_x, y = row_mid_y + box_text_offset_y, label = ttl_exp_lbl, size = 2.5) +
+        # first segments
+        annotate("text", x = col_1_x + arrow_label_offset_x,
+                 y = row_mid_y + arrow_label_offset_y,
+                 label = "Listed Equity",
+                 size = 2.5, angle = arrow_label_angle) +
+        geom_segment(
+          x = col_1_x + box_width, xend = col_2_x,
+          y = row_mid_y + box_text_offset_y, yend = row_top_y + box_text_offset_y,
+          linewidth = arrow_linewidth, linejoin = "mitre", lineend = "butt",
+          arrow = arrow(length = unit(arrow_length_mm, "mm"), type= "closed")
+        ) +
+        annotate("text", x = col_1_x + arrow_label_offset_x,
+                 y = row_mid_y - arrow_label_offset_y + box_height,
+                 label = "Corporate Bonds",
+                 size = 2.5, angle = -arrow_label_angle) +
+        geom_segment(
+          x = col_1_x + box_width, xend = col_2_x,
+          y = row_mid_y + box_text_offset_y, yend = row_bottom_y + box_text_offset_y,
+          linewidth = arrow_linewidth, linejoin = "mitre", lineend = "butt",
+          arrow = arrow(length = unit(arrow_length_mm, "mm"), type= "closed")
+        ) +
+        # exposure per asset class
+        annotate("text", x = col_2_x + box_label_offset_x, y = row_top_y + box_label_offset_y, label = "Exposure per asset class", size = 2.5) +
+        # equity exposure
+        geom_rect(xmin = col_2_x, xmax = col_2_x + box_width,
+                  ymin = row_top_y, ymax = row_top_y + box_height,
+                  color = "black", fill = "white", linewidth = box_linewidth) +
+        annotate("text", x = col_2_x + box_text_offset_x, y = row_top_y + box_text_offset_y, label = eq_exp_lbl, size = 2.5) +
+        # bond exposure
+        geom_rect(xmin = col_2_x, xmax = col_2_x + box_width,
+                  ymin = row_bottom_y, ymax = row_bottom_y + box_height,
+                  color = "black", fill = "white", linewidth = box_linewidth) +
+        annotate("text", x = col_2_x + box_text_offset_x, y = row_bottom_y + box_text_offset_y, label = cb_exp_lbl, size = 2.5) +
+        # second segments
+        geom_segment(
+          x = col_2_x + box_width, xend = col_3_x,
+          y = row_top_y + box_text_offset_y, yend = row_top_y + box_text_offset_y,
+          linewidth = arrow_linewidth, linejoin = "mitre", lineend = "butt",
+          arrow = arrow(length = unit(arrow_length_mm, "mm"), type= "closed")
+        ) +
+        geom_segment(
+          x = col_2_x + box_width, xend = col_3_x,
+          y = row_bottom_y + box_text_offset_y, yend = row_bottom_y + box_text_offset_y,
+          linewidth = arrow_linewidth, linejoin = "mitre", lineend = "butt",
+          arrow = arrow(length = unit(arrow_length_mm, "mm"), type= "closed")
+        ) +
+        # exposure to PACTA sectors per asset class
+        annotate("text", x = col_3_x + box_label_offset_x, y = row_top_y + box_label_offset_y, label = "Exposure covered by PACTA sectors*\n(as % of asset class exposure", size = 2.5) +
+        # equity PACTA exposure
+        geom_rect(xmin = col_3_x, xmax = col_3_x + box_width,
+                  ymin = row_top_y, ymax = row_top_y + box_height,
+                  color = "black", fill = "white", linewidth = box_linewidth) +
+        annotate("text", x = col_3_x + box_text_offset_x, y = row_top_y + box_text_offset_y, label = eq_pacta_exp_lbl, size = 2.5) +
+        # bond PACTA exposure
+        geom_rect(xmin = col_3_x, xmax = col_3_x + box_width,
+                  ymin = row_bottom_y, ymax = row_bottom_y + box_height,
+                  color = "black", fill = "white", linewidth = box_linewidth) +
+        annotate("text", x = col_3_x + box_text_offset_x, y = row_bottom_y + box_text_offset_y, label = cb_pacta_exp_lbl, size = 2.5) +
+        # third segments
+        geom_segment(
+          x = col_3_x + box_width, xend = col_4_x,
+          y = row_top_y + box_text_offset_y, yend = row_top_y + box_text_offset_y,
+          linewidth = arrow_linewidth, linejoin = "mitre", lineend = "butt",
+          arrow = arrow(length = unit(arrow_length_mm, "mm"), type= "closed")
+        ) +
+        geom_segment(
+          x = col_3_x + box_width, xend = col_4_x,
+          y = row_bottom_y + box_text_offset_y, yend = row_bottom_y + box_text_offset_y,
+          linewidth = arrow_linewidth, linejoin = "mitre", lineend = "butt",
+          arrow = arrow(length = unit(arrow_length_mm, "mm"), type= "closed")
+        ) +
+        # emissions per asset class
+        annotate("text", x = col_4_x + box_label_offset_x, y = row_top_y + box_label_offset_y, label = "Emissions covered by PACTA sectors*\n(as % of asset class emissions", size = 2.5) +
+        # equity emissions
+        geom_rect(xmin = col_4_x, xmax = col_4_x + box_width,
+                  ymin = row_top_y, ymax = row_top_y + box_height,
+                  color = "black", fill = "white", linewidth = box_linewidth) +
+        annotate("text", x = col_4_x + box_text_offset_x, y = row_top_y + box_text_offset_y, label = eq_emiss_exp_lbl, size = 2.5) +
+        # bond PACTA exposure
+        geom_rect(xmin = col_4_x, xmax = col_4_x + box_width,
+                  ymin = row_bottom_y, ymax = row_bottom_y + box_height,
+                  color = "black", fill = "white", linewidth = box_linewidth) +
+        annotate("text", x = col_4_x + box_text_offset_x, y = row_bottom_y + box_text_offset_y, label = cb_emiss_exp_lbl, size = 2.5)
+    },
+    error = function (e) {
+      cat("There was an error in plot_diagram().\nReturning empty plot object.\n")
+      empty_plot_error_message()
+    }
+  )
 }
 
 check_data_diagram <- function(data, env) {

--- a/R/plot_diagram.R
+++ b/R/plot_diagram.R
@@ -114,7 +114,7 @@ plot_diagram <- function(data = NULL) {
       arrow_label_offset_y <- row_top_y - row_mid_y + (box_height / 2) - 3
       arrow_label_angle <- 27
 
-      ggplot(tibble(x = 0:100, y = 0:100), aes(x = .data$x, y = .data$y)) +
+      p <- ggplot(tibble(x = 0:100, y = 0:100), aes(x = .data$x, y = .data$y)) +
         theme_void() +
         scale_y_continuous(limits = c(0, 50)) +
         # total exposure
@@ -209,9 +209,10 @@ plot_diagram <- function(data = NULL) {
     },
     error = function (e) {
       cat("There was an error in plot_diagram().\nReturning empty plot object.\n")
-      empty_plot_error_message()
+      p <- empty_plot_error_message()
     }
   )
+  p
 }
 
 check_data_diagram <- function(data, env) {

--- a/R/plot_emissions_scorecard.R
+++ b/R/plot_emissions_scorecard.R
@@ -13,51 +13,59 @@
 #' @examples
 #' plot_emissions_scorecard(toy_data_emissions_scorecard)
 plot_emissions_scorecard <- function(data) {
-  env <- list(data = substitute(data))
-  check_data_emissions_scorecard(data, env = env)
+  tryCatch(
+    {
+      env <- list(data = substitute(data))
+      check_data_emissions_scorecard(data, env = env)
 
-  data <- data %>%
-    mutate(
-      entity = r2dii.plot::to_title(.data$entity),
-      entity = factor(
-        .data$entity,
-        levels = r2dii.plot::to_title(c("portfolio", "benchmark"))
-      ),
-      asset_class = factor(.data$asset_class, levels = c("equity", "bonds"))
-    )
-
-  p <- ggplot(data, aes(x = .data$entity, y = .data$emissions, fill = .data$entity)) +
-    geom_bar(stat = "identity") +
-    geom_text(
-      aes(
-        y = .data$emissions * 1.05,
-        label = paste(
-          format(.data$emissions, big.mark = ","),
-          " tonnes"
+      data <- data %>%
+        mutate(
+          entity = r2dii.plot::to_title(.data$entity),
+          entity = factor(
+            .data$entity,
+            levels = r2dii.plot::to_title(c("portfolio", "benchmark"))
+          ),
+          asset_class = factor(.data$asset_class, levels = c("equity", "bonds"))
         )
-      ),
-      size = 5
-    ) +
-    scale_y_continuous(
-      expand = expansion(mult = c(0, 0.1)),
-      name = expression(atop("Carbon footprint", "(tonnes" * CO[2] * ")"))
-    ) +
-    scale_fill_manual(
-      values = c(
-        unname(fill_colours_entities_scores["portfolio"]),
-        unname(fill_colours_entities_scores["benchmark"])
-      )
-    ) +
-    theme_2dii(base_size = 22) +
-    theme(
-      axis.title.x = element_blank(),
-      axis.line = element_blank(),
-      axis.ticks = element_blank(),
-      axis.text.y = element_blank(),
-      strip.text = element_text(face = "bold"),
-      legend.position = "none"
-    ) +
-    facet_wrap(~asset_class, labeller = as_labeller(r2dii.plot::to_title))
+
+      p <- ggplot(data, aes(x = .data$entity, y = .data$emissions, fill = .data$entity)) +
+        geom_bar(stat = "identity") +
+        geom_text(
+          aes(
+            y = .data$emissions * 1.05,
+            label = paste(
+              format(.data$emissions, big.mark = ","),
+              " tonnes"
+            )
+          ),
+          size = 5
+        ) +
+        scale_y_continuous(
+          expand = expansion(mult = c(0, 0.1)),
+          name = expression(atop("Carbon footprint", "(tonnes" * CO[2] * ")"))
+        ) +
+        scale_fill_manual(
+          values = c(
+            unname(fill_colours_entities_scores["portfolio"]),
+            unname(fill_colours_entities_scores["benchmark"])
+          )
+        ) +
+        theme_2dii(base_size = 22) +
+        theme(
+          axis.title.x = element_blank(),
+          axis.line = element_blank(),
+          axis.ticks = element_blank(),
+          axis.text.y = element_blank(),
+          strip.text = element_text(face = "bold"),
+          legend.position = "none"
+        ) +
+        facet_wrap(~asset_class, labeller = as_labeller(r2dii.plot::to_title))
+    },
+    error = function (e) {
+      cat("There was an error in plot_emissions_scorecard().\nReturning empty plot object.\n")
+      p <- empty_plot_error_message()
+    }
+  )
   p
 }
 

--- a/R/plot_exposures_scorecard.R
+++ b/R/plot_exposures_scorecard.R
@@ -14,39 +14,47 @@
 #' @examples
 #' plot_exposures_scorecard(toy_data_exposures_scorecard)
 plot_exposures_scorecard <- function(data) {
-  env <- list(data = substitute(data))
-  check_data_exposures_scorecard(data, env = env)
+  tryCatch(
+    {
+      env <- list(data = substitute(data))
+      check_data_exposures_scorecard(data, env = env)
 
-  p <- ggplot(
-    data,
-    aes(
-      x = .data$sector_or_tech,
-      y = .data$exposure_perc_aum,
-      fill = .data$sector_or_tech
-    )
-  ) +
-    geom_bar(stat = "identity") +
-    geom_text(
-      aes(
-        y = .data$exposure_perc_aum,
-        label = scales::percent(round(.data$exposure_perc_aum, digits = 2))
-      ),
-      hjust = -0.2,
-      size = 7
-    ) +
-    scale_x_discrete(labels = r2dii.plot::to_title) +
-    scale_y_continuous(expand = expansion(mult = c(0, .8)), labels = scales::percent) +
-    scale_fill_manual(values = fill_colours_exposures_scorecard) +
-    coord_flip() +
-    theme_2dii(base_size = 24) +
-    theme(
-      axis.title = element_blank(),
-      axis.line.x = element_blank(),
-      axis.ticks = element_blank(),
-      axis.text.x = element_blank(),
-      legend.position = "none"
-    ) +
-    facet_wrap(~asset_class, labeller = as_labeller(r2dii.plot::to_title))
+      p <- ggplot(
+        data,
+        aes(
+          x = .data$sector_or_tech,
+          y = .data$exposure_perc_aum,
+          fill = .data$sector_or_tech
+        )
+      ) +
+        geom_bar(stat = "identity") +
+        geom_text(
+          aes(
+            y = .data$exposure_perc_aum,
+            label = scales::percent(round(.data$exposure_perc_aum, digits = 2))
+          ),
+          hjust = -0.2,
+          size = 7
+        ) +
+        scale_x_discrete(labels = r2dii.plot::to_title) +
+        scale_y_continuous(expand = expansion(mult = c(0, .8)), labels = scales::percent) +
+        scale_fill_manual(values = fill_colours_exposures_scorecard) +
+        coord_flip() +
+        theme_2dii(base_size = 24) +
+        theme(
+          axis.title = element_blank(),
+          axis.line.x = element_blank(),
+          axis.ticks = element_blank(),
+          axis.text.x = element_blank(),
+          legend.position = "none"
+        ) +
+        facet_wrap(~asset_class, labeller = as_labeller(r2dii.plot::to_title))
+    },
+    error = function (e) {
+      cat("There was an error in plot_exposures_scorecard().\nReturning empty plot object.\n")
+      p <- empty_plot_error_message()
+    }
+  )
   p
 }
 

--- a/R/plot_exposures_survey.R
+++ b/R/plot_exposures_survey.R
@@ -19,35 +19,43 @@
 #'
 #' plot_exposures_survey(data)
 plot_exposures_survey <- function(data) {
-  env <- list(data = substitute(data))
-  check_data_exposures_survey(data, env = env)
+  tryCatch(
+    {
+      env <- list(data = substitute(data))
+      check_data_exposures_survey(data, env = env)
 
-  data <- data %>%
-    mutate(
-      entity = factor(.data$entity, levels = c("portfolio", "peers"))
-    ) %>%
-    dplyr::arrange(.data$entity)
+      data <- data %>%
+        mutate(
+          entity = factor(.data$entity, levels = c("portfolio", "peers"))
+        ) %>%
+        dplyr::arrange(.data$entity)
 
-  p <- ggplot(
-    data,
-    aes(
-      x = .data$entity,
-      y = .data$exposure_perc_aum,
-      fill = .data$sector,
-      alpha = .data$entity
-    )
-  ) +
-    geom_bar(stat = "identity") +
-    scale_x_discrete(labels = r2dii.plot::to_title) +
-    scale_y_continuous(expand = expansion(mult = c(0, .1)), labels = scales::percent) +
-    r2dii.colours::scale_fill_2dii(palette = "pacta", colour_groups = data$sector) +
-    scale_alpha_discrete(range = c(1, 0.7)) +
-    theme_2dii(base_size = 24) +
-    theme(
-      legend.position = "none",
-      axis.title = element_blank(),
-      axis.ticks.x = element_blank()
-    )
+      p <- ggplot(
+        data,
+        aes(
+          x = .data$entity,
+          y = .data$exposure_perc_aum,
+          fill = .data$sector,
+          alpha = .data$entity
+        )
+      ) +
+        geom_bar(stat = "identity") +
+        scale_x_discrete(labels = r2dii.plot::to_title) +
+        scale_y_continuous(expand = expansion(mult = c(0, .1)), labels = scales::percent) +
+        r2dii.colours::scale_fill_2dii(palette = "pacta", colour_groups = data$sector) +
+        scale_alpha_discrete(range = c(1, 0.7)) +
+        theme_2dii(base_size = 24) +
+        theme(
+          legend.position = "none",
+          axis.title = element_blank(),
+          axis.ticks.x = element_blank()
+        )
+    },
+    error = function (e) {
+      cat("There was an error in plot_exposures_survey().\nReturning empty plot object.\n")
+      p <- empty_plot_error_message()
+    }
+  )
   p
 }
 

--- a/R/plot_fossil_bars.R
+++ b/R/plot_fossil_bars.R
@@ -14,52 +14,60 @@
 #' @examples
 #' plot_fossil_bars(toy_data_fossil_bars)
 plot_fossil_bars <- function(data) {
-  env <- list(data = substitute(data))
-  check_data_fossil_bars(data, env = env)
+  tryCatch(
+    {
+      env <- list(data = substitute(data))
+      check_data_fossil_bars(data, env = env)
 
-  data <- data %>%
-    mutate(
-      entity_name_title = r2dii.plot::to_title(.data$entity_name),
-      entity_title = r2dii.plot::to_title(.data$entity),
-      entity_title = factor(
-        .data$entity_title,
-        levels = r2dii.plot::to_title(c("index", "peers", "portfolio"))
-      )
-    )
+      data <- data %>%
+        mutate(
+          entity_name_title = r2dii.plot::to_title(.data$entity_name),
+          entity_title = r2dii.plot::to_title(.data$entity),
+          entity_title = factor(
+            .data$entity_title,
+            levels = r2dii.plot::to_title(c("index", "peers", "portfolio"))
+          )
+        )
 
-  p <- ggplot(data, aes(x = .data$entity_title, y = .data$perc_aum, fill = .data$entity_type)) +
-    geom_bar(stat = "identity") +
-    geom_text(
-      aes(
-        y = .data$perc_aum,
-        label = scales::percent(round(.data$perc_aum, digits = 4))
-      ),
-      hjust = -0.2,
-      size = 7
-    ) +
-    scale_y_continuous(expand = expansion(mult = c(0, .4))) +
-    scale_fill_manual(
-      values = fill_colours_fossil_bars,
-      labels = fill_labels_fossil_bars,
-    ) +
-    coord_flip() +
-    theme_2dii(base_size = 28) +
-    theme(
-      axis.title = element_blank(),
-      axis.line.x = element_blank(),
-      axis.ticks = element_blank(),
-      axis.text.x = element_blank(),
-      strip.text = element_text(face = "bold"),
-      legend.position = "bottom",
-      strip.placement = "outside"
-    ) +
-    facet_grid(tech ~ asset_class, labeller = as_labeller(r2dii.plot::to_title), switch = "y") +
-    labs(
-      caption = make_caption_indices(data)
-    ) +
-    theme(
-      plot.caption = element_text(size = 16)
-    )
+      p <- ggplot(data, aes(x = .data$entity_title, y = .data$perc_aum, fill = .data$entity_type)) +
+        geom_bar(stat = "identity") +
+        geom_text(
+          aes(
+            y = .data$perc_aum,
+            label = scales::percent(round(.data$perc_aum, digits = 4))
+          ),
+          hjust = -0.2,
+          size = 7
+        ) +
+        scale_y_continuous(expand = expansion(mult = c(0, .4))) +
+        scale_fill_manual(
+          values = fill_colours_fossil_bars,
+          labels = fill_labels_fossil_bars,
+        ) +
+        coord_flip() +
+        theme_2dii(base_size = 28) +
+        theme(
+          axis.title = element_blank(),
+          axis.line.x = element_blank(),
+          axis.ticks = element_blank(),
+          axis.text.x = element_blank(),
+          strip.text = element_text(face = "bold"),
+          legend.position = "bottom",
+          strip.placement = "outside"
+        ) +
+        facet_grid(tech ~ asset_class, labeller = as_labeller(r2dii.plot::to_title), switch = "y") +
+        labs(
+          caption = make_caption_indices(data)
+        ) +
+        theme(
+          plot.caption = element_text(size = 16)
+        )
+    },
+    error = function (e) {
+      cat("There was an error in plot_fossil_bars().\nReturning empty plot object.\n")
+      p <- empty_plot_error_message()
+    }
+  )
   p
 }
 

--- a/R/plot_green_brown_bars.R
+++ b/R/plot_green_brown_bars.R
@@ -15,48 +15,56 @@
 #' @examples
 #' plot_green_brown_bars(toy_data_green_brown_bars)
 plot_green_brown_bars <- function(data) {
-  env <- list(data = substitute(data))
-  check_data_green_brown_bars(data, env = env)
+  tryCatch(
+    {
+      env <- list(data = substitute(data))
+      check_data_green_brown_bars(data, env = env)
 
-  data <- data %>%
-    mutate(
-      tech_type = r2dii.plot::to_title(.data$tech_type),
-      tech_type = factor(
-        .data$tech_type,
-        levels = r2dii.plot::to_title(c("green", "nuclear", "brown", "other"))
-      ),
-      sector = r2dii.plot::to_title(.data$sector),
-      sector_reordered = tidytext::reorder_within(.data$sector, .data$perc_sec_exposure, .data$asset_class)
-    )
+      data <- data %>%
+        mutate(
+          tech_type = r2dii.plot::to_title(.data$tech_type),
+          tech_type = factor(
+            .data$tech_type,
+            levels = r2dii.plot::to_title(c("green", "nuclear", "brown", "other"))
+          ),
+          sector = r2dii.plot::to_title(.data$sector),
+          sector_reordered = tidytext::reorder_within(.data$sector, .data$perc_sec_exposure, .data$asset_class)
+        )
 
-  p <- ggplot(data, aes(x = .data$sector_reordered, y = .data$perc_tech_exposure, fill = .data$tech_type)) +
-    geom_bar(stat = "identity") +
-    geom_text(
-      aes(
-        y = .data$perc_sec_exposure,
-        # TODO: refine percentages
-        label = scales::percent(round(.data$perc_sec_exposure, digits = 3))
-      ),
-      hjust = -0.2,
-      size = 7
-    ) +
-    tidytext::scale_x_reordered() +
-    scale_y_continuous(expand = expansion(mult = c(0, .4)), labels = scales::percent) +
-    scale_fill_manual(
-      values = fill_colours_green_brown_bars,
-      labels = fill_labels_green_brown_bars,
-    ) +
-    coord_flip() +
-    theme_2dii(base_size = 28) +
-    theme(
-      axis.title = element_blank(),
-      axis.line.x = element_blank(),
-      axis.ticks = element_blank(),
-      axis.text.x = element_blank(),
-      strip.text = element_text(face = "bold"),
-      legend.position = "bottom"
-    ) +
-    facet_wrap(~asset_class, scales = "free", labeller = as_labeller(r2dii.plot::to_title))
+      p <- ggplot(data, aes(x = .data$sector_reordered, y = .data$perc_tech_exposure, fill = .data$tech_type)) +
+        geom_bar(stat = "identity") +
+        geom_text(
+          aes(
+            y = .data$perc_sec_exposure,
+            # TODO: refine percentages
+            label = scales::percent(round(.data$perc_sec_exposure, digits = 3))
+          ),
+          hjust = -0.2,
+          size = 7
+        ) +
+        tidytext::scale_x_reordered() +
+        scale_y_continuous(expand = expansion(mult = c(0, .4)), labels = scales::percent) +
+        scale_fill_manual(
+          values = fill_colours_green_brown_bars,
+          labels = fill_labels_green_brown_bars,
+        ) +
+        coord_flip() +
+        theme_2dii(base_size = 28) +
+        theme(
+          axis.title = element_blank(),
+          axis.line.x = element_blank(),
+          axis.ticks = element_blank(),
+          axis.text.x = element_blank(),
+          strip.text = element_text(face = "bold"),
+          legend.position = "bottom"
+        ) +
+        facet_wrap(~asset_class, scales = "free", labeller = as_labeller(r2dii.plot::to_title))
+    },
+    error = function (e) {
+      cat("There was an error in plot_green_brown_bars().\nReturning empty plot object.\n")
+      p <- empty_plot_error_message()
+    }
+  )
   p
 }
 

--- a/R/plot_scatter.R
+++ b/R/plot_scatter.R
@@ -19,141 +19,149 @@
 #'
 #' plot_scatter(toy_data_scatter %>% filter(asset_class == "equity"))
 plot_scatter <- function(data) {
-  stopifnot(is.data.frame(data))
-  
-  if (nrow(data) > 0) {
-    env <- list(data = substitute(data))
-    check_data_scatter(data, env = env)
-    
-    data <- data %>%
-      dplyr::inner_join(alignment_scores_values, by = c("score" = "score_symbol")) %>%
-      select(-.data$category, -.data$score_upper) %>%
-      mutate(
-        score_symbol = .data$score,
-        score = .data$score_label,
-        entity_type = factor(.data$entity_type, levels = c("this_portfolio", "peers", "peers_mean", "benchmark"))
-      ) 
-  
-    score_bar <- plot_basic_scorebar() +
-      geom_point(
-        data = data %>%
-          mutate(category = "score"),
-        aes(
-          color = .data$entity_type,
-          y = .data$score,
-          fill = "black",
-          shape = .data$entity_type,
-          size = 1.5
-        ),
-        position = position_dodge(width = 0.2)
-      ) +
-      scale_colour_2dii(colour_groups = data$entity_type) +
-      scale_shape_manual(
-        values = c("peers_mean" = 16, "peers" = 1, "this_portfolio" = 16, "benchmark" = 16),
-        labels = r2dii.plot::to_title(levels(data$entity_type))
-      ) +
-      theme(
-        axis.title.y = element_text()
-      ) +
-      labs(
-        y = axis_labels_scatter["y"]
-      )
-  
-    p <- ggplot(
-      data,
-      aes(
-        x = .data$tech_mix_green,
-        y = .data$score,
-        color = .data$entity_type,
-        shape = .data$entity_type,
-        size = 1.5
-      )
-    ) +
-      geom_point() +
-      geom_vline(xintercept = 0.5, linetype = "dashed", color = "#C0C0C0") +
-      geom_hline(yintercept = alignment_scores_values$score_upper[2], linetype = "dashed", color = "#C0C0C0") +
-      scale_y_continuous(
-        limits = c(1, 100),
-        breaks = alignment_scores_values$score_label,
-        labels = alignment_scores_values$score_symbol,
-        expand = expansion(mult = c(0, 0.1))
-      ) +
-      scale_x_continuous(
-        labels = scales::percent,
-        limits = c(0, 1),
-        expand = expansion(mult = c(0, 0.1))
-      ) +
-      scale_shape_manual(
-        values = c("peers_mean" = 16, "peers" = 1, "this_portfolio" = 16, "benchmark" = 16),
-        labels = r2dii.plot::to_title(levels(data$entity_type))
-      ) +
-      scale_colour_2dii(colour_groups = data$entity_type) +
-      theme_2dii(
-        base_size = 20
-      ) +
-      theme(
-        axis.ticks.y = element_blank(),
-        axis.title = element_blank(),
-        legend.position = "none"
-      ) +
-      guides(shape = "none", size = "none")
-  
-    tech_mix <- tibble(
-      tech_mix_green = seq(from = 0.05, to = 1, by = 0.05),
-      category = "techmix"
-    )
-  
-    tech_mix_bar_fut <- ggplot(
-      tech_mix,
-      aes(x = .data$category, y = .data$tech_mix_green, fill = .data$tech_mix_green)
-    ) +
-      geom_bar(stat = "identity", position = "fill") +
-      geom_point(
-        data = data %>%
-          mutate(category = "techmix"),
-        aes(color = .data$entity_type, shape = .data$entity_type, size = 1.5),
-        position = position_dodge(width = 0.2)
-      ) +
-      coord_flip() +
-      scale_y_continuous(
-        labels = scales::percent,
-        expand = expansion(mult = c(0, 0.1))
-      ) +
-      scale_fill_gradient(low = fill_colours_techmix["brown"], high = fill_colours_techmix["green"]) +
-      scale_colour_2dii(colour_groups = data$entity_type) +
-      scale_shape_manual(
-        values = c("peers_mean" = 16, "peers" = 1, "this_portfolio" = 16, "benchmark" = 16),
-        labels = r2dii.plot::to_title(levels(data$entity_type))
-      ) +
-      theme_2dii(
-        base_size = 20
-      ) +
-      theme(
-        axis.title.y = element_blank(),
-        axis.ticks.y = element_blank(),
-        axis.text.y = element_blank(),
-        legend.position = "none"
-      ) +
-      labs(y = axis_labels_scatter["x"])
-  
-    p_out <- score_bar + p + guide_area() + tech_mix_bar_fut +
-      plot_layout(ncol = 2, widths = c(0.7, 3.8), heights = c(3.8, 1), guides = "collect") +
-      theme(
-        legend.position = "left",
-        legend.title = element_text()
-      ) +
-      guides(
-        size = "none",
-        shape = "none",
-        fill = "none",
-        colour = guide_legend(
-          title = axis_labels_scatter["legend_title"],
-         override.aes = list(size = 4, shape = c(16, 1, 16, 16))
+  tryCatch(
+    {
+      stopifnot(is.data.frame(data))
+
+      if (nrow(data) > 0) {
+        env <- list(data = substitute(data))
+        check_data_scatter(data, env = env)
+
+        data <- data %>%
+          dplyr::inner_join(alignment_scores_values, by = c("score" = "score_symbol")) %>%
+          select(-.data$category, -.data$score_upper) %>%
+          mutate(
+            score_symbol = .data$score,
+            score = .data$score_label,
+            entity_type = factor(.data$entity_type, levels = c("this_portfolio", "peers", "peers_mean", "benchmark"))
+          )
+
+        score_bar <- plot_basic_scorebar() +
+          geom_point(
+            data = data %>%
+              mutate(category = "score"),
+            aes(
+              color = .data$entity_type,
+              y = .data$score,
+              fill = "black",
+              shape = .data$entity_type,
+              size = 1.5
+            ),
+            position = position_dodge(width = 0.2)
+          ) +
+          scale_colour_2dii(colour_groups = data$entity_type) +
+          scale_shape_manual(
+            values = c("peers_mean" = 16, "peers" = 1, "this_portfolio" = 16, "benchmark" = 16),
+            labels = r2dii.plot::to_title(levels(data$entity_type))
+          ) +
+          theme(
+            axis.title.y = element_text()
+          ) +
+          labs(
+            y = axis_labels_scatter["y"]
+          )
+
+        p <- ggplot(
+          data,
+          aes(
+            x = .data$tech_mix_green,
+            y = .data$score,
+            color = .data$entity_type,
+            shape = .data$entity_type,
+            size = 1.5
+          )
+        ) +
+          geom_point() +
+          geom_vline(xintercept = 0.5, linetype = "dashed", color = "#C0C0C0") +
+          geom_hline(yintercept = alignment_scores_values$score_upper[2], linetype = "dashed", color = "#C0C0C0") +
+          scale_y_continuous(
+            limits = c(1, 100),
+            breaks = alignment_scores_values$score_label,
+            labels = alignment_scores_values$score_symbol,
+            expand = expansion(mult = c(0, 0.1))
+          ) +
+          scale_x_continuous(
+            labels = scales::percent,
+            limits = c(0, 1),
+            expand = expansion(mult = c(0, 0.1))
+          ) +
+          scale_shape_manual(
+            values = c("peers_mean" = 16, "peers" = 1, "this_portfolio" = 16, "benchmark" = 16),
+            labels = r2dii.plot::to_title(levels(data$entity_type))
+          ) +
+          scale_colour_2dii(colour_groups = data$entity_type) +
+          theme_2dii(
+            base_size = 20
+          ) +
+          theme(
+            axis.ticks.y = element_blank(),
+            axis.title = element_blank(),
+            legend.position = "none"
+          ) +
+          guides(shape = "none", size = "none")
+
+        tech_mix <- tibble(
+          tech_mix_green = seq(from = 0.05, to = 1, by = 0.05),
+          category = "techmix"
         )
-      )
-  } else {
-    p_out <- empty_plot_no_data_message()
-  }
+
+        tech_mix_bar_fut <- ggplot(
+          tech_mix,
+          aes(x = .data$category, y = .data$tech_mix_green, fill = .data$tech_mix_green)
+        ) +
+          geom_bar(stat = "identity", position = "fill") +
+          geom_point(
+            data = data %>%
+              mutate(category = "techmix"),
+            aes(color = .data$entity_type, shape = .data$entity_type, size = 1.5),
+            position = position_dodge(width = 0.2)
+          ) +
+          coord_flip() +
+          scale_y_continuous(
+            labels = scales::percent,
+            expand = expansion(mult = c(0, 0.1))
+          ) +
+          scale_fill_gradient(low = fill_colours_techmix["brown"], high = fill_colours_techmix["green"]) +
+          scale_colour_2dii(colour_groups = data$entity_type) +
+          scale_shape_manual(
+            values = c("peers_mean" = 16, "peers" = 1, "this_portfolio" = 16, "benchmark" = 16),
+            labels = r2dii.plot::to_title(levels(data$entity_type))
+          ) +
+          theme_2dii(
+            base_size = 20
+          ) +
+          theme(
+            axis.title.y = element_blank(),
+            axis.ticks.y = element_blank(),
+            axis.text.y = element_blank(),
+            legend.position = "none"
+          ) +
+          labs(y = axis_labels_scatter["x"])
+
+        p_out <- score_bar + p + guide_area() + tech_mix_bar_fut +
+          plot_layout(ncol = 2, widths = c(0.7, 3.8), heights = c(3.8, 1), guides = "collect") +
+          theme(
+            legend.position = "left",
+            legend.title = element_text()
+          ) +
+          guides(
+            size = "none",
+            shape = "none",
+            fill = "none",
+            colour = guide_legend(
+              title = axis_labels_scatter["legend_title"],
+              override.aes = list(size = 4, shape = c(16, 1, 16, 16))
+            )
+          )
+      } else {
+        p_out <- empty_plot_no_data_message()
+      }
+    },
+    error = function (e) {
+      cat("There was an error in plot_scatter().\nReturning empty plot object.\n")
+      p_out <- empty_plot_error_message()
+    }
+  )
   p_out
 }
 

--- a/R/plot_scores.R
+++ b/R/plot_scores.R
@@ -18,42 +18,50 @@
 #'
 #' plot_scores(toy_data_scores %>% filter(asset_class == "equity"))
 plot_scores <- function(data) {
-  stopifnot(is.data.frame(data))
-  if (nrow(data) > 0) {
-    env <- list(data = substitute(data))
-    check_data_scores(data, env = env)
-  
-    data <- data %>%
-      dplyr::inner_join(alignment_scores_values, by = c("score" = "score_symbol")) %>%
-      select(-c("category", "score_delta", "score_upper")) %>%
-      mutate(
-        score_symbol = .data$score
-      )
-  
-    p_portfolio <- plot_score_portfolio(data %>% filter(.data$scope == "portfolio")) +
-      labs(subtitle = "Portfolio")
+  tryCatch(
+    {
+      stopifnot(is.data.frame(data))
+      if (nrow(data) > 0) {
+        env <- list(data = substitute(data))
+        check_data_scores(data, env = env)
 
-    p_power <- plot_score_sector(data, "power")
-  
-    p_auto <- plot_score_sector(data, "automotive")
-  
-    p_coal <- plot_score_sector(data, "coal")
-  
-    p_gas <- plot_score_sector(data, "gas")
-  
-    p_steel <- plot_score_sector(data, "steel")
-  
-    p_aviation <- plot_score_sector(data, "aviation")
-  
-    p_oil <- plot_score_sector(data, "oil")
-  
-    p_sector_up <- p_power + p_auto + p_coal + p_gas + plot_layout(ncol = 4)
-    p_sector_down <- p_steel + p_aviation + p_oil + legend_scores() + plot_layout(ncol = 4)
-  
-    p <- p_portfolio + (p_sector_up / p_sector_down) + plot_layout(widths = c(1, 6))
-  } else {
-    p <- empty_plot_no_data_message()
-  }
+        data <- data %>%
+          dplyr::inner_join(alignment_scores_values, by = c("score" = "score_symbol")) %>%
+          select(-c("category", "score_delta", "score_upper")) %>%
+          mutate(
+            score_symbol = .data$score
+          )
+
+        p_portfolio <- plot_score_portfolio(data %>% filter(.data$scope == "portfolio")) +
+          labs(subtitle = "Portfolio")
+
+        p_power <- plot_score_sector(data, "power")
+
+        p_auto <- plot_score_sector(data, "automotive")
+
+        p_coal <- plot_score_sector(data, "coal")
+
+        p_gas <- plot_score_sector(data, "gas")
+
+        p_steel <- plot_score_sector(data, "steel")
+
+        p_aviation <- plot_score_sector(data, "aviation")
+
+        p_oil <- plot_score_sector(data, "oil")
+
+        p_sector_up <- p_power + p_auto + p_coal + p_gas + plot_layout(ncol = 4)
+        p_sector_down <- p_steel + p_aviation + p_oil + legend_scores() + plot_layout(ncol = 4)
+
+        p <- p_portfolio + (p_sector_up / p_sector_down) + plot_layout(widths = c(1, 6))
+      } else {
+        p <- empty_plot_no_data_message()
+      }
+    },
+    error = function (e) {
+      cat("There was an error in plot_scores().\nReturning empty plot object.\n")
+      p <- empty_plot_error_message()
+    }
+  )
   p
 }
 

--- a/R/plot_scores_scorecard.R
+++ b/R/plot_scores_scorecard.R
@@ -17,22 +17,30 @@
 #'   )
 #' plot_scores_scorecard(data)
 plot_scores_scorecard <- function(data) {
-  env <- list(data = substitute(data))
-  check_data_scores_scorecard(data, env)
+  tryCatch(
+    {
+      env <- list(data = substitute(data))
+      check_data_scores_scorecard(data, env)
 
-  p <- plot_scores_scorecard_single(data) +
-    geom_text(
-      data = annotation_df(),
-      aes(x = 3.65, y = 91, label = .data$text),
-      colour = "black"
-    ) +
-    theme(
-      strip.text = element_text(face = "bold")
-    ) +
-    facet_wrap(
-      ~ factor(.data$asset_class, levels = c("bonds", "equity")),
-      labeller = as_labeller(r2dii.plot::to_title)
-    )
+      p <- plot_scores_scorecard_single(data) +
+        geom_text(
+          data = annotation_df(),
+          aes(x = 3.65, y = 91, label = .data$text),
+          colour = "black"
+        ) +
+        theme(
+          strip.text = element_text(face = "bold")
+        ) +
+        facet_wrap(
+          ~ factor(.data$asset_class, levels = c("bonds", "equity")),
+          labeller = as_labeller(r2dii.plot::to_title)
+        )
+    },
+    error = function (e) {
+      cat("There was an error in plot_scores_scorecard().\nReturning empty plot object.\n")
+      p <- empty_plot_error_message()
+    }
+  )
   p
 }
 

--- a/R/prep_alignment_table.R
+++ b/R/prep_alignment_table.R
@@ -20,84 +20,92 @@ prep_alignment_table <- function(results_portfolio,
                                  peers_results_aggregated,
                                  asset_class = c("equity", "bonds"),
                                  scenario_source = "GECO2021") {
-  if (is.null(results_portfolio)) {
-    data_out <- use_toy_data("alignment_table") %>% filter(asset_class == .env$asset_class)
-  } else {
-    # validate inputs
-    match.arg(asset_class)
-    check_data_prep_alignment_table(scenario_source = scenario_source)
+  tryCatch(
+    {
+      if (is.null(results_portfolio)) {
+        data_out <- use_toy_data("alignment_table") %>% filter(asset_class == .env$asset_class)
+      } else {
+        # validate inputs
+        match.arg(asset_class)
+        check_data_prep_alignment_table(scenario_source = scenario_source)
 
-    portfolio_data_asset <- results_portfolio %>% 
-      filter(asset_class == .env$asset_class)
-    if (nrow(portfolio_data_asset) > 0) {
-      # infer start_year
-    start_year <- min(results_portfolio$year, na.rm = TRUE)
+        portfolio_data_asset <- results_portfolio %>%
+          filter(asset_class == .env$asset_class)
+        if (nrow(portfolio_data_asset) > 0) {
+          # infer start_year
+          start_year <- min(results_portfolio$year, na.rm = TRUE)
 
-    # filter selected asset_class
-    data <- results_portfolio %>%
-      dplyr::bind_rows(peers_results_aggregated)
+          # filter selected asset_class
+          data <- results_portfolio %>%
+            dplyr::bind_rows(peers_results_aggregated)
 
-    # get scenarios
-    scenario_thresholds <- get("scenario_thresholds")
+          # get scenarios
+          scenario_thresholds <- get("scenario_thresholds")
 
-    scenarios <- scenario_thresholds %>%
-      dplyr::filter(.data$scenario_source == .env$scenario_source) %>%
-      dplyr::pull("scenario")
+          scenarios <- scenario_thresholds %>%
+            dplyr::filter(.data$scenario_source == .env$scenario_source) %>%
+            dplyr::pull("scenario")
 
-    # get scenarios for relevant thresholds
-    scenario_high_ambition <- scenario_thresholds %>%
-      dplyr::filter(.data$threshold == "high") %>%
-      dplyr::pull("scenario")
+          # get scenarios for relevant thresholds
+          scenario_high_ambition <- scenario_thresholds %>%
+            dplyr::filter(.data$threshold == "high") %>%
+            dplyr::pull("scenario")
 
-    scenario_medium_ambition <- scenario_thresholds %>%
-      dplyr::filter(.data$threshold == "mid") %>%
-      dplyr::pull("scenario")
+          scenario_medium_ambition <- scenario_thresholds %>%
+            dplyr::filter(.data$threshold == "mid") %>%
+            dplyr::pull("scenario")
 
-    # prepare data for technology alignment calculation
-    data_tech_alignment <- data %>%
-      wrangle_input_data_alignment_table(scenarios = scenarios)
+          # prepare data for technology alignment calculation
+          data_tech_alignment <- data %>%
+            wrangle_input_data_alignment_table(scenarios = scenarios)
 
-    # calculate technology level alignment
-    data_tech_alignment <- data_tech_alignment %>%
-      calculate_technology_alignment(
-        start_year = start_year,
-        time_horizon = time_horizon_lookup
-      )
+          # calculate technology level alignment
+          data_tech_alignment <- data_tech_alignment %>%
+            calculate_technology_alignment(
+              start_year = start_year,
+              time_horizon = time_horizon_lookup
+            )
 
-    # calculate the traffic light for each technology
-    data_tech_alignment_color <- data_tech_alignment %>%
-      calculate_tech_traffic_light(
-        scenario_high_ambition = scenario_high_ambition,
-        scenario_medium_ambition = scenario_medium_ambition
-      )
+          # calculate the traffic light for each technology
+          data_tech_alignment_color <- data_tech_alignment %>%
+            calculate_tech_traffic_light(
+              scenario_high_ambition = scenario_high_ambition,
+              scenario_medium_ambition = scenario_medium_ambition
+            )
 
-    # map green/brown categories
-    data_tech_alignment_color <- data_tech_alignment_color %>%
-      dplyr::mutate(
-        green_or_brown = dplyr::case_when(
-          .data$green_or_brown == "green" ~ "Low-carbon",
-          .data$green_or_brown == "brown" ~ "High-carbon",
-          TRUE ~ .data$green_or_brown
-        )
-      )
+          # map green/brown categories
+          data_tech_alignment_color <- data_tech_alignment_color %>%
+            dplyr::mutate(
+              green_or_brown = dplyr::case_when(
+                .data$green_or_brown == "green" ~ "Low-carbon",
+                .data$green_or_brown == "brown" ~ "High-carbon",
+                TRUE ~ .data$green_or_brown
+              )
+            )
 
-    # select the relevant variables
-    data_out <- data_tech_alignment_color %>%
-      dplyr::select(
-        c("ald_sector", "technology", "asset_class", "entity", "aligned_scen_temp",
-          "plan_carsten", "green_or_brown")
-      ) %>%
-      dplyr::rename(
-        sector = "ald_sector",
-        perc_aum = "plan_carsten",
-        green_brown = "green_or_brown"
-      ) %>%
-      filter(.data$asset_class == .env$asset_class)
-    } else {
-      data_out <- toy_data_alignment_table[0L, ]
+          # select the relevant variables
+          data_out <- data_tech_alignment_color %>%
+            dplyr::select(
+              c("ald_sector", "technology", "asset_class", "entity", "aligned_scen_temp",
+                "plan_carsten", "green_or_brown")
+            ) %>%
+            dplyr::rename(
+              sector = "ald_sector",
+              perc_aum = "plan_carsten",
+              green_brown = "green_or_brown"
+            ) %>%
+            filter(.data$asset_class == .env$asset_class)
+        } else {
+          data_out <- toy_data_alignment_table[0L, ]
+        }
+      }
+      data_out
+    },
+    error = function (e) {
+      cat("There was an error in prep_alignment_table().\nReturning empty plot object.\n")
+      data_out <- empty_plot_error_message()
     }
-  } 
-  data_out
+  )
 }
 
 check_data_prep_alignment_table <- function(scenario_source) {

--- a/R/prep_climate_strategy_scorecard.R
+++ b/R/prep_climate_strategy_scorecard.R
@@ -17,48 +17,56 @@
 prep_climate_strategy_scorecard_initiatives <- function(data,
                                                         data_peers,
                                                         peer_group = c("pensionfund", "assetmanager", "bank", "insurance", "other")) {
-  # match input arg
-  peer_group <- match.arg(peer_group)
+  tryCatch(
+    {
+      # match input arg
+      peer_group <- match.arg(peer_group)
 
-  # check peer groups match
-  check_data_prep_climate_strategy_scorecard(
-    data = data,
-    peer_group = peer_group
+      # check peer groups match
+      check_data_prep_climate_strategy_scorecard(
+        data = data,
+        peer_group = peer_group
+      )
+
+      # prepare data sets
+      data <- data %>%
+        dplyr::mutate(entity_type = "this_portfolio") %>%
+        dplyr::mutate(yes = sum(.data$climate_initiative, na.rm = TRUE)) %>%
+        dplyr::filter(.data$peer_group == .env$peer_group) %>%
+        dplyr::select(c("entity_type", "peer_group", "yes", "name_climate_initiative"))
+
+      data_peers <- data_peers %>%
+        dplyr::mutate(
+          entity_type = "peers",
+          name_climate_initiative = NA_character_
+        ) %>%
+        dplyr::filter(.data$peer_group == .env$peer_group) %>%
+        dplyr::select(c("entity_type", "peer_group", yes = "peers_yes", "name_climate_initiative"))
+
+      # combine data sets
+      climate_strategy_scorecard_initiatives <- data %>%
+        dplyr::bind_rows(data_peers)
+
+      member_initiatives_portfolio <- climate_strategy_scorecard_initiatives %>%
+        dplyr::filter(.data$entity_type == "this_portfolio") %>%
+        dplyr::select(c("yes", "name_climate_initiative"))
+
+      member_initiatives_peers <- climate_strategy_scorecard_initiatives %>%
+        dplyr::filter(.data$entity_type == "peers") %>%
+        dplyr::pull("yes")
+
+      climate_strategy_scorecard_initiatives <- list(
+        member_initiatives_portfolio = member_initiatives_portfolio,
+        member_initiatives_peers = member_initiatives_peers
+      )
+
+      return(climate_strategy_scorecard_initiatives)
+    },
+    error = function (e) {
+      cat("There was an error in\nprep_climate_strategy_scorecard_initiatives().\nReturning empty plot object.\n")
+      data_out <- empty_plot_error_message()
+    }
   )
-
-  # prepare data sets
-  data <- data %>%
-    dplyr::mutate(entity_type = "this_portfolio") %>%
-    dplyr::mutate(yes = sum(.data$climate_initiative, na.rm = TRUE)) %>%
-    dplyr::filter(.data$peer_group == .env$peer_group) %>%
-    dplyr::select(c("entity_type", "peer_group", "yes", "name_climate_initiative"))
-
-  data_peers <- data_peers %>%
-    dplyr::mutate(
-      entity_type = "peers",
-      name_climate_initiative = NA_character_
-    ) %>%
-    dplyr::filter(.data$peer_group == .env$peer_group) %>%
-    dplyr::select(c("entity_type", "peer_group", yes = "peers_yes", "name_climate_initiative"))
-
-  # combine data sets
-  climate_strategy_scorecard_initiatives <- data %>%
-    dplyr::bind_rows(data_peers)
-
-  member_initiatives_portfolio <- climate_strategy_scorecard_initiatives %>%
-    dplyr::filter(.data$entity_type == "this_portfolio") %>%
-    dplyr::select(c("yes", "name_climate_initiative"))
-
-  member_initiatives_peers <- climate_strategy_scorecard_initiatives %>%
-    dplyr::filter(.data$entity_type == "peers") %>%
-    dplyr::pull("yes")
-
-  climate_strategy_scorecard_initiatives <- list(
-    member_initiatives_portfolio = member_initiatives_portfolio,
-    member_initiatives_peers = member_initiatives_peers
-  )
-
-  return(climate_strategy_scorecard_initiatives)
 }
 
 #' Prepare data input for climate strategy metrics (engagement) in the scorecard
@@ -79,57 +87,65 @@ prep_climate_strategy_scorecard_initiatives <- function(data,
 prep_climate_strategy_scorecard_engagement <- function(data,
                                                        data_peers,
                                                        peer_group = c("pensionfund", "assetmanager", "bank", "insurance", "other")) {
-  # match input arg
-  peer_group <- match.arg(peer_group)
+  tryCatch(
+    {
+      # match input arg
+      peer_group <- match.arg(peer_group)
 
-  # check peer groups match
-  check_data_prep_climate_strategy_scorecard(
-    data = data,
-    peer_group = peer_group
-  )
-
-  # prepare data sets
-  data <- data %>%
-    dplyr::mutate(entity_type = "this_portfolio") %>%
-    dplyr::mutate(
-      yes = dplyr::if_else(.data$engagement == "yes", 1, 0),
-      no = dplyr::if_else(.data$engagement == "no", 1, 0),
-      not_answered = dplyr::if_else(.data$engagement == "not_answered", 1, 0)
-    ) %>%
-    dplyr::filter(.data$peer_group == .env$peer_group) %>%
-    dplyr::select(c("entity_type", "peer_group", "asset_type", "yes", "no", "not_answered"))
-
-  data_peers <- data_peers %>%
-    dplyr::mutate(entity_type = "peers") %>%
-    dplyr::filter(.data$peer_group == .env$peer_group) %>%
-    dplyr::rename_with(~ gsub("peers_", "", .x, fixed = TRUE)) %>%
-    dplyr::select(c("entity_type", "peer_group", "asset_type", "yes", "no", "not_answered"))
-
-  # combine data sets
-  climate_strategy_scorecard_engagement <- data %>%
-    dplyr::bind_rows(data_peers)
-
-  engagement_portfolio <- climate_strategy_scorecard_engagement %>%
-    filter(.data$entity_type == "this_portfolio") %>%
-    mutate(
-      answer = dplyr::case_when(
-        yes == 1 ~ "YES",
-        no == 1 ~ "NO",
-        TRUE ~ "Not Answered"
+      # check peer groups match
+      check_data_prep_climate_strategy_scorecard(
+        data = data,
+        peer_group = peer_group
       )
-    ) %>%
-    dplyr::select(c("asset_type", "answer"))
 
-  engagement_peers <- climate_strategy_scorecard_engagement %>%
-    filter(.data$entity_type == "peers") %>%
-    dplyr::select(c("asset_type", "yes"))
+      # prepare data sets
+      data <- data %>%
+        dplyr::mutate(entity_type = "this_portfolio") %>%
+        dplyr::mutate(
+          yes = dplyr::if_else(.data$engagement == "yes", 1, 0),
+          no = dplyr::if_else(.data$engagement == "no", 1, 0),
+          not_answered = dplyr::if_else(.data$engagement == "not_answered", 1, 0)
+        ) %>%
+        dplyr::filter(.data$peer_group == .env$peer_group) %>%
+        dplyr::select(c("entity_type", "peer_group", "asset_type", "yes", "no", "not_answered"))
 
-  climate_strategy_scorecard_engagement <- list(
-    engagement_portfolio = engagement_portfolio,
-    engagement_peers = engagement_peers
+      data_peers <- data_peers %>%
+        dplyr::mutate(entity_type = "peers") %>%
+        dplyr::filter(.data$peer_group == .env$peer_group) %>%
+        dplyr::rename_with(~ gsub("peers_", "", .x, fixed = TRUE)) %>%
+        dplyr::select(c("entity_type", "peer_group", "asset_type", "yes", "no", "not_answered"))
+
+      # combine data sets
+      climate_strategy_scorecard_engagement <- data %>%
+        dplyr::bind_rows(data_peers)
+
+      engagement_portfolio <- climate_strategy_scorecard_engagement %>%
+        filter(.data$entity_type == "this_portfolio") %>%
+        mutate(
+          answer = dplyr::case_when(
+            yes == 1 ~ "YES",
+            no == 1 ~ "NO",
+            TRUE ~ "Not Answered"
+          )
+        ) %>%
+        dplyr::select(c("asset_type", "answer"))
+
+      engagement_peers <- climate_strategy_scorecard_engagement %>%
+        filter(.data$entity_type == "peers") %>%
+        dplyr::select(c("asset_type", "yes"))
+
+      climate_strategy_scorecard_engagement <- list(
+        engagement_portfolio = engagement_portfolio,
+        engagement_peers = engagement_peers
+      )
+
+      return(climate_strategy_scorecard_engagement)
+    },
+    error = function (e) {
+      cat("There was an error in\nprep_climate_strategy_scorecard_engagement().\nReturning empty plot object.\n")
+      data_out <- empty_plot_error_message()
+    }
   )
-
-  return(climate_strategy_scorecard_engagement)
 }
 
 #' Prepare data input for climate strategy metrics (voting rights) in the scorecard
@@ -151,57 +167,65 @@ prep_climate_strategy_scorecard_engagement <- function(data,
 prep_climate_strategy_scorecard_voting <- function(data,
                                                    data_peers,
                                                    peer_group = c("pensionfund", "assetmanager", "bank", "insurance", "other")) {
-  # match input arg
-  peer_group <- match.arg(peer_group)
+  tryCatch(
+    {
+      # match input arg
+      peer_group <- match.arg(peer_group)
 
-  # check peer groups match
-  check_data_prep_climate_strategy_scorecard(
-    data = data,
-    peer_group = peer_group
-  )
-
-  # prepare data sets
-  data <- data %>%
-    dplyr::mutate(entity_type = "this_portfolio") %>%
-    dplyr::mutate(
-      yes = dplyr::if_else(.data$voting_rights == "yes", 1, 0),
-      no = dplyr::if_else(.data$voting_rights == "no", 1, 0),
-      not_answered = dplyr::if_else(.data$voting_rights == "not_answered", 1, 0)
-    ) %>%
-    dplyr::filter(.data$peer_group == .env$peer_group) %>%
-    dplyr::select(c("entity_type", "peer_group", "asset_type", "yes", "no", "not_answered"))
-
-  data_peers <- data_peers %>%
-    dplyr::mutate(entity_type = "peers") %>%
-    dplyr::filter(.data$peer_group == .env$peer_group) %>%
-    dplyr::rename_with(~ gsub("peers_", "", .x, fixed = TRUE)) %>%
-    dplyr::select(c("entity_type", "peer_group", "asset_type", "yes", "no", "not_answered"))
-
-  # combine data sets
-  climate_strategy_scorecard_voting <- data %>%
-    dplyr::bind_rows(data_peers)
-
-  voting_rights_portfolio <- climate_strategy_scorecard_voting %>%
-    filter(.data$entity_type == "this_portfolio") %>%
-    mutate(
-      answer = dplyr::case_when(
-        yes == 1 ~ "YES",
-        no == 1 ~ "NO",
-        TRUE ~ "Not Answered"
+      # check peer groups match
+      check_data_prep_climate_strategy_scorecard(
+        data = data,
+        peer_group = peer_group
       )
-    ) %>%
-    dplyr::select(c("asset_type", "answer"))
 
-  voting_rights_peers <- climate_strategy_scorecard_voting %>%
-    filter(.data$entity_type == "peers") %>%
-    dplyr::select(c("asset_type", "yes"))
+      # prepare data sets
+      data <- data %>%
+        dplyr::mutate(entity_type = "this_portfolio") %>%
+        dplyr::mutate(
+          yes = dplyr::if_else(.data$voting_rights == "yes", 1, 0),
+          no = dplyr::if_else(.data$voting_rights == "no", 1, 0),
+          not_answered = dplyr::if_else(.data$voting_rights == "not_answered", 1, 0)
+        ) %>%
+        dplyr::filter(.data$peer_group == .env$peer_group) %>%
+        dplyr::select(c("entity_type", "peer_group", "asset_type", "yes", "no", "not_answered"))
 
-  climate_strategy_scorecard_voting <- list(
-    voting_rights_portfolio = voting_rights_portfolio,
-    voting_rights_peers = voting_rights_peers
+      data_peers <- data_peers %>%
+        dplyr::mutate(entity_type = "peers") %>%
+        dplyr::filter(.data$peer_group == .env$peer_group) %>%
+        dplyr::rename_with(~ gsub("peers_", "", .x, fixed = TRUE)) %>%
+        dplyr::select(c("entity_type", "peer_group", "asset_type", "yes", "no", "not_answered"))
+
+      # combine data sets
+      climate_strategy_scorecard_voting <- data %>%
+        dplyr::bind_rows(data_peers)
+
+      voting_rights_portfolio <- climate_strategy_scorecard_voting %>%
+        filter(.data$entity_type == "this_portfolio") %>%
+        mutate(
+          answer = dplyr::case_when(
+            yes == 1 ~ "YES",
+            no == 1 ~ "NO",
+            TRUE ~ "Not Answered"
+          )
+        ) %>%
+        dplyr::select(c("asset_type", "answer"))
+
+      voting_rights_peers <- climate_strategy_scorecard_voting %>%
+        filter(.data$entity_type == "peers") %>%
+        dplyr::select(c("asset_type", "yes"))
+
+      climate_strategy_scorecard_voting <- list(
+        voting_rights_portfolio = voting_rights_portfolio,
+        voting_rights_peers = voting_rights_peers
+      )
+
+      return(climate_strategy_scorecard_voting)
+    },
+    error = function (e) {
+      cat("There was an error in\nprep_climate_strategy_scorecard_voting().\nReturning empty plot object.\n")
+      data_out <- empty_plot_error_message()
+    }
   )
-
-  return(climate_strategy_scorecard_voting)
 }
 
 check_data_prep_climate_strategy_scorecard <- function(data,

--- a/R/prep_diagram.R
+++ b/R/prep_diagram.R
@@ -6,88 +6,95 @@
 #' @return Some output
 #' @export
 prep_diagram <- function(audit_data = NULL, emissions_data = NULL) {
-  if (is.null(audit_data) | is.null(emissions_data)) {
-    data_out <- use_toy_data("diagram")
-  }
+  tryCatch(
+    {
+      if (is.null(audit_data) | is.null(emissions_data)) {
+        data_out <- use_toy_data("diagram")
+      }
 
-  audit_data <- audit_data %>%
-    dplyr::filter(.data$entity == "portfolio") %>%
-    dplyr::mutate(exposure_portfolio = sum(.data$value_usd, na.rm = TRUE)) %>%
-    dplyr::group_by(.data$asset_type) %>%
-    dplyr::mutate(
-      exposure_asset_class = sum(.data$value_usd, na.rm = TRUE),
-      exposure_asset_class_perc = .data$exposure_asset_class / .data$exposure_portfolio
-    ) %>%
-    dplyr::ungroup() %>%
-    dplyr::mutate(
-      covered_pacta = dplyr::if_else(
-        .data$financial_sector %in% c("Automotive", "Coal", "Oil&Gas", "Power", "Aviation", "Cement", "Steel"),
-        TRUE,
-        FALSE
-      )
-    ) %>%
-    dplyr::group_by(
-      .data$asset_type, .data$exposure_portfolio, .data$covered_pacta,
-      .data$exposure_asset_class, .data$exposure_asset_class_perc
-    ) %>%
-    dplyr::summarise(
-      exposure_pacta = sum(.data$value_usd, na.rm = TRUE),
-      .groups = "drop"
-    ) %>%
-    dplyr::mutate(
-      exposure_pacta_perc_asset_class_exposure = .data$exposure_pacta / .data$exposure_asset_class
-    ) %>%
-    dplyr::ungroup() %>%
-    dplyr::filter(.data$covered_pacta) %>%
-    dplyr::select(
-      c("exposure_portfolio", "asset_type", "exposure_asset_class",
-        "exposure_asset_class_perc", "exposure_pacta", "exposure_pacta_perc_asset_class_exposure")
-    )
+      audit_data <- audit_data %>%
+        dplyr::filter(.data$entity == "portfolio") %>%
+        dplyr::mutate(exposure_portfolio = sum(.data$value_usd, na.rm = TRUE)) %>%
+        dplyr::group_by(.data$asset_type) %>%
+        dplyr::mutate(
+          exposure_asset_class = sum(.data$value_usd, na.rm = TRUE),
+          exposure_asset_class_perc = .data$exposure_asset_class / .data$exposure_portfolio
+        ) %>%
+        dplyr::ungroup() %>%
+        dplyr::mutate(
+          covered_pacta = dplyr::if_else(
+            .data$financial_sector %in% c("Automotive", "Coal", "Oil&Gas", "Power", "Aviation", "Cement", "Steel"),
+            TRUE,
+            FALSE
+          )
+        ) %>%
+        dplyr::group_by(
+          .data$asset_type, .data$exposure_portfolio, .data$covered_pacta,
+          .data$exposure_asset_class, .data$exposure_asset_class_perc
+        ) %>%
+        dplyr::summarise(
+          exposure_pacta = sum(.data$value_usd, na.rm = TRUE),
+          .groups = "drop"
+        ) %>%
+        dplyr::mutate(
+          exposure_pacta_perc_asset_class_exposure = .data$exposure_pacta / .data$exposure_asset_class
+        ) %>%
+        dplyr::ungroup() %>%
+        dplyr::filter(.data$covered_pacta) %>%
+        dplyr::select(
+          c("exposure_portfolio", "asset_type", "exposure_asset_class",
+            "exposure_asset_class_perc", "exposure_pacta", "exposure_pacta_perc_asset_class_exposure")
+        )
 
-  emissions_data <- emissions_data %>%
-    dplyr::filter(.data$entity == "portfolio") %>%
-    dplyr::group_by(.data$asset_type) %>%
-    # TODO: check if this what we need or if it needs to be divivded by the asset value covered
-    dplyr::mutate(emissions_asset = sum(.data$weighted_sector_emissions, na.rm = TRUE)) %>%
-    dplyr::ungroup() %>%
-    dplyr::mutate(
-      covered_pacta = dplyr::if_else(
-        .data$sector %in% c("Automotive", "Coal", "Oil&Gas", "Power", "Aviation", "Cement", "Steel"),
-        TRUE,
-        FALSE
-      )
-    ) %>%
-    dplyr::group_by(.data$asset_type, .data$covered_pacta, .data$emissions_asset) %>%
-    dplyr::summarise(
-      emissions_pacta = sum(.data$weighted_sector_emissions, na.rm = TRUE),
-      .groups = "drop"
-    ) %>%
-    dplyr::ungroup() %>%
-    dplyr::mutate(emissions_pacta_perc = .data$emissions_pacta / .data$emissions_asset) %>%
-    dplyr::filter(.data$covered_pacta) %>%
-    dplyr::select(c("asset_type", "emissions_pacta_perc", "emissions_pacta"))
+      emissions_data <- emissions_data %>%
+        dplyr::filter(.data$entity == "portfolio") %>%
+        dplyr::group_by(.data$asset_type) %>%
+        # TODO: check if this what we need or if it needs to be divivded by the asset value covered
+        dplyr::mutate(emissions_asset = sum(.data$weighted_sector_emissions, na.rm = TRUE)) %>%
+        dplyr::ungroup() %>%
+        dplyr::mutate(
+          covered_pacta = dplyr::if_else(
+            .data$sector %in% c("Automotive", "Coal", "Oil&Gas", "Power", "Aviation", "Cement", "Steel"),
+            TRUE,
+            FALSE
+          )
+        ) %>%
+        dplyr::group_by(.data$asset_type, .data$covered_pacta, .data$emissions_asset) %>%
+        dplyr::summarise(
+          emissions_pacta = sum(.data$weighted_sector_emissions, na.rm = TRUE),
+          .groups = "drop"
+        ) %>%
+        dplyr::ungroup() %>%
+        dplyr::mutate(emissions_pacta_perc = .data$emissions_pacta / .data$emissions_asset) %>%
+        dplyr::filter(.data$covered_pacta) %>%
+        dplyr::select(c("asset_type", "emissions_pacta_perc", "emissions_pacta"))
 
-  data_out <- audit_data %>%
-    dplyr::inner_join(emissions_data, by = "asset_type") %>%
-    dplyr::rename(asset_class = "asset_type") %>%
-    dplyr::mutate(asset_class = tolower(.data$asset_class))
+      data_out <- audit_data %>%
+        dplyr::inner_join(emissions_data, by = "asset_type") %>%
+        dplyr::rename(asset_class = "asset_type") %>%
+        dplyr::mutate(asset_class = tolower(.data$asset_class))
 
-  missing_asset_types <- setdiff(c("equity", "bonds"), unique(data_out$asset_class))
+      missing_asset_types <- setdiff(c("equity", "bonds"), unique(data_out$asset_class))
 
-  if (any(c("equity", "bonds") %in% missing_asset_types)) {
-    missing_assets <- tibble::tibble(
-      exposure_portfolio = unique(data_out$exposure_portfolio),
-      asset_class = missing_asset_types,
-      exposure_asset_class = 0,
-      exposure_asset_class_perc = 0,
-      exposure_pacta = 0,
-      exposure_pacta_perc_asset_class_exposure = 0,
-      emissions_pacta_perc = 0,
-      emissions_pacta = 0
-    )
+      if (any(c("equity", "bonds") %in% missing_asset_types)) {
+        missing_assets <- tibble::tibble(
+          exposure_portfolio = unique(data_out$exposure_portfolio),
+          asset_class = missing_asset_types,
+          exposure_asset_class = 0,
+          exposure_asset_class_perc = 0,
+          exposure_pacta = 0,
+          exposure_pacta_perc_asset_class_exposure = 0,
+          emissions_pacta_perc = 0,
+          emissions_pacta = 0
+        )
 
-    data_out <- rbind(data_out, missing_assets)
-  }
-
-  return(data_out)
+        data_out <- rbind(data_out, missing_assets)
+      }
+      return(data_out)
+    },
+    error = function (e) {
+      cat("There was an error in prep_diagram().\nReturning empty plot object.\n")
+      data_out <- empty_plot_error_message()
+    }
+  )
 }

--- a/R/prep_emissions_scorecard.R
+++ b/R/prep_emissions_scorecard.R
@@ -9,51 +9,60 @@
 prep_emissions_scorecard <- function(emissions_data = NULL,
                                      audit_data,
                                      currency_exchange_value) {
-  if (is.null(emissions_data)) {
-    data_out <- use_toy_data("emissions_scorecard")
-  }
+  tryCatch(
+    {
+      if (is.null(emissions_data)) {
+        data_out <- use_toy_data("emissions_scorecard")
+      }
 
-  portfolio_value_currency_asset_type <- audit_data %>%
-    dplyr::filter(.data$asset_type %in% c("Equity", "Bonds")) %>%
-    dplyr::group_by(.data$asset_type, .data$entity) %>%
-    dplyr::summarise(
-      value_curr_mio = sum(.data$value_usd / .env$currency_exchange_value, na.rm = TRUE) / 1000000,
-      .groups = "drop"
-    ) %>%
-    dplyr::ungroup() %>%
-    dplyr::mutate(asset_class = tolower(.data$asset_type)) %>%
-    dplyr::select(-"asset_type")
+      portfolio_value_currency_asset_type <- audit_data %>%
+        dplyr::filter(.data$asset_type %in% c("Equity", "Bonds")) %>%
+        dplyr::group_by(.data$asset_type, .data$entity) %>%
+        dplyr::summarise(
+          value_curr_mio = sum(.data$value_usd / .env$currency_exchange_value, na.rm = TRUE) / 1000000,
+          .groups = "drop"
+        ) %>%
+        dplyr::ungroup() %>%
+        dplyr::mutate(asset_class = tolower(.data$asset_type)) %>%
+        dplyr::select(-"asset_type")
 
 
-  emissions_asset_entity <- emissions_data %>%
-    dplyr::group_by(.data$asset_type, .data$entity) %>%
-    dplyr::mutate(emissions_asset = sum(.data$weighted_sector_emissions, na.rm = TRUE)) %>%
-    dplyr::ungroup() %>%
-    dplyr::mutate(
-      covered_pacta = dplyr::if_else(
-        .data$sector %in% c("Automotive", "Coal", "Oil&Gas", "Power", "Aviation", "Cement", "Steel"),
-        TRUE,
-        FALSE
-      )
-    ) %>%
-    dplyr::group_by(.data$asset_type, .data$entity, .data$covered_pacta, .data$emissions_asset) %>%
-    dplyr::summarise(
-      emissions = sum(.data$weighted_sector_emissions, na.rm = TRUE),
-      .groups = "drop"
-    ) %>%
-    dplyr::ungroup() %>%
-    dplyr::filter(.data$covered_pacta) %>%
-    dplyr::select(c("asset_type", "entity", "emissions")) %>%
-    dplyr::rename(asset_class = "asset_type") %>%
-    dplyr::mutate(asset_class = tolower(.data$asset_class))
+      emissions_asset_entity <- emissions_data %>%
+        dplyr::group_by(.data$asset_type, .data$entity) %>%
+        dplyr::mutate(emissions_asset = sum(.data$weighted_sector_emissions, na.rm = TRUE)) %>%
+        dplyr::ungroup() %>%
+        dplyr::mutate(
+          covered_pacta = dplyr::if_else(
+            .data$sector %in% c("Automotive", "Coal", "Oil&Gas", "Power", "Aviation", "Cement", "Steel"),
+            TRUE,
+            FALSE
+          )
+        ) %>%
+        dplyr::group_by(.data$asset_type, .data$entity, .data$covered_pacta, .data$emissions_asset) %>%
+        dplyr::summarise(
+          emissions = sum(.data$weighted_sector_emissions, na.rm = TRUE),
+          .groups = "drop"
+        ) %>%
+        dplyr::ungroup() %>%
+        dplyr::filter(.data$covered_pacta) %>%
+        dplyr::select(c("asset_type", "entity", "emissions")) %>%
+        dplyr::rename(asset_class = "asset_type") %>%
+        dplyr::mutate(asset_class = tolower(.data$asset_class))
 
-  data_out <- emissions_asset_entity %>%
-    dplyr::inner_join(
-      portfolio_value_currency_asset_type,
-      by = c("asset_class", "entity")
-    ) %>%
-    dplyr::mutate(emissions = round(.data$emissions / .data$value_curr_mio, 1)) %>%
-    dplyr::select(c("asset_class", "entity", "emissions"))
+      data_out <- emissions_asset_entity %>%
+        dplyr::inner_join(
+          portfolio_value_currency_asset_type,
+          by = c("asset_class", "entity")
+        ) %>%
+        dplyr::mutate(emissions = round(.data$emissions / .data$value_curr_mio, 1)) %>%
+        dplyr::select(c("asset_class", "entity", "emissions"))
 
-  return(data_out)
+      return(data_out)
+    },
+    error = function (e) {
+      cat("There was an error in prep_emissions_scorecard().\nReturning empty plot object.\n")
+      data_out <- empty_plot_error_message()
+    }
+  )
+
 }

--- a/R/prep_exposures_scorecard.R
+++ b/R/prep_exposures_scorecard.R
@@ -15,30 +15,38 @@
 #' @export
 prep_exposures_scorecard <- function(results_portfolio,
                                      scenario_selected = "1.5C-Unif") {
-  if (is.null(results_portfolio)) {
-    data_out <- use_toy_data("exposures_scorecard")
-  } else {
-    # check input
-    check_data_prep_exposures_scorecard(scenario_selected = scenario_selected)
+  tryCatch(
+    {
+      if (is.null(results_portfolio)) {
+        data_out <- use_toy_data("exposures_scorecard")
+      } else {
+        # check input
+        check_data_prep_exposures_scorecard(scenario_selected = scenario_selected)
 
-    # input data
-    data <- results_portfolio
+        # input data
+        data <- results_portfolio
 
-    # infer start year
-    start_year <- min(data$year, na.rm = TRUE)
+        # infer start year
+        start_year <- min(data$year, na.rm = TRUE)
 
-    # filter data
-    data <- data %>%
-      dplyr::filter(
-        .data$year == .env$start_year,
-        .data$scenario == .env$scenario_selected
-      )
+        # filter data
+        data <- data %>%
+          dplyr::filter(
+            .data$year == .env$start_year,
+            .data$scenario == .env$scenario_selected
+          )
 
-    # calculate current exposures and wrangle for score card
-    data_out <- data %>%
-      wrangle_data_exposures_scorecard()
-  }
-  data_out
+        # calculate current exposures and wrangle for score card
+        data_out <- data %>%
+          wrangle_data_exposures_scorecard()
+      }
+      data_out
+    },
+    error = function (e) {
+      cat("There was an error in prep_exposures_scorecard().\nReturning empty plot object.\n")
+      data_out <- empty_plot_error_message()
+    }
+  )
 }
 
 check_data_prep_exposures_scorecard <- function(scenario_selected) {

--- a/R/prep_exposures_survey.R
+++ b/R/prep_exposures_survey.R
@@ -21,50 +21,58 @@ prep_exposures_survey <- function(results_portfolio,
                                   peers_results_aggregated,
                                   sector = c("coal", "oil_and_gas"),
                                   asset_class = c("equity", "bonds")) {
-  if (is.null(results_portfolio)) {
-    data_out <- use_toy_data("exposures_survey") %>%
-      filter(
-        .data$asset_class == .env$asset_class,
-        .data$sector == .env$sector
-      )
-  } else {
-    # validate inputs
-    sector <- match.arg(sector)
-    asset_class <- match.arg(asset_class)
+  tryCatch(
+    {
+      if (is.null(results_portfolio)) {
+        data_out <- use_toy_data("exposures_survey") %>%
+          filter(
+            .data$asset_class == .env$asset_class,
+            .data$sector == .env$sector
+          )
+      } else {
+        # validate inputs
+        sector <- match.arg(sector)
+        asset_class <- match.arg(asset_class)
 
-    check_data_prep_exposures_survey(
-      asset_class = asset_class,
-      sector = sector
-    )
+        check_data_prep_exposures_survey(
+          asset_class = asset_class,
+          sector = sector
+        )
 
-    # infer start year
-    start_year <- min(results_portfolio$year, na.rm = TRUE)
+        # infer start year
+        start_year <- min(results_portfolio$year, na.rm = TRUE)
 
-    # pick scenario for filtering (no impact on current exposure)
-    scenario_filter <- "1.5C-Unif"
+        # pick scenario for filtering (no impact on current exposure)
+        scenario_filter <- "1.5C-Unif"
 
-    # combine input data
-    data <- results_portfolio %>%
-      dplyr::bind_rows(peers_results_aggregated)
+        # combine input data
+        data <- results_portfolio %>%
+          dplyr::bind_rows(peers_results_aggregated)
 
-    # calculate current exposures
-    data <- data %>%
-      dplyr::filter(
-        .data$year == .env$start_year,
-        .data$scenario == .env$scenario_filter
-      )
+        # calculate current exposures
+        data <- data %>%
+          dplyr::filter(
+            .data$year == .env$start_year,
+            .data$scenario == .env$scenario_filter
+          )
 
-    # wrangle to expected format
-    data <- data %>%
-      wrangle_data_exposures_survey()
+        # wrangle to expected format
+        data <- data %>%
+          wrangle_data_exposures_survey()
 
-    data_out <- data %>%
-      dplyr::filter(
-        .data$asset_class == .env$asset_class,
-        .data$sector == .env$sector
-      )
-  }
-  data_out
+        data_out <- data %>%
+          dplyr::filter(
+            .data$asset_class == .env$asset_class,
+            .data$sector == .env$sector
+          )
+      }
+      data_out
+    },
+    error = function (e) {
+      cat("There was an error in prep_exposures_survey().\nReturning empty plot object.\n")
+      data_out <- empty_plot_error_message()
+    }
+  )
 }
 
 check_data_prep_exposures_survey <- function(asset_class,

--- a/R/prep_fossil_bars.R
+++ b/R/prep_fossil_bars.R
@@ -21,33 +21,41 @@ prep_fossil_bars <- function(results_portfolio,
                              peers_results_aggregated,
                              indices_results_portfolio,
                              scenario_selected = "1.5C-Unif") {
-  if (is.null(results_portfolio)) {
-    data_out <- use_toy_data("fossil_bars")
-  } else {
-    # check input
-    check_data_prep_fossil_bars(scenario_selected = scenario_selected)
+  tryCatch(
+    {
+      if (is.null(results_portfolio)) {
+        data_out <- use_toy_data("fossil_bars")
+      } else {
+        # check input
+        check_data_prep_fossil_bars(scenario_selected = scenario_selected)
 
-    # combine input data sets
-    data <- results_portfolio %>%
-      dplyr::bind_rows(peers_results_aggregated) %>%
-      dplyr::bind_rows(indices_results_portfolio)
+        # combine input data sets
+        data <- results_portfolio %>%
+          dplyr::bind_rows(peers_results_aggregated) %>%
+          dplyr::bind_rows(indices_results_portfolio)
 
-    # infer start year
-    start_year <- min(data$year, na.rm = TRUE)
+        # infer start year
+        start_year <- min(data$year, na.rm = TRUE)
 
-    # filter combined input data
-    data <- data %>%
-      dplyr::filter(
-        .data$year == .env$start_year,
-        .data$scenario == .env$scenario_selected,
-        .data$ald_sector %in% c("Coal", "Oil&Gas")
-      )
+        # filter combined input data
+        data <- data %>%
+          dplyr::filter(
+            .data$year == .env$start_year,
+            .data$scenario == .env$scenario_selected,
+            .data$ald_sector %in% c("Coal", "Oil&Gas")
+          )
 
-    # wrangle data into output format
-    data_out <- data %>%
-      wrangle_data_fossil_bars()
-  }
-  data_out
+        # wrangle data into output format
+        data_out <- data %>%
+          wrangle_data_fossil_bars()
+      }
+      data_out
+    },
+    error = function (e) {
+      cat("There was an error in prep_fossil_bars().\nReturning empty plot object.\n")
+      data_out <- empty_plot_error_message()
+    }
+  )
 }
 
 check_data_prep_fossil_bars <- function(scenario_selected) {

--- a/R/prep_green_brown_bars.R
+++ b/R/prep_green_brown_bars.R
@@ -14,40 +14,48 @@
 #' @export
 prep_green_brown_bars <- function(results_portfolio,
                                   scenario_selected = "1.5C-Unif") {
-  if (is.null(results_portfolio)) {
-    data_out <- use_toy_data("green_brown_bars")
-  } else {
-    # check input
-    check_data_prep_green_brown_bars(scenario_selected = scenario_selected)
+  tryCatch(
+    {
+      if (is.null(results_portfolio)) {
+        data_out <- use_toy_data("green_brown_bars")
+      } else {
+        # check input
+        check_data_prep_green_brown_bars(scenario_selected = scenario_selected)
 
-    # input data
-    data <- results_portfolio
+        # input data
+        data <- results_portfolio
 
-    # infer start year
-    start_year <- min(data$year, na.rm = TRUE)
+        # infer start year
+        start_year <- min(data$year, na.rm = TRUE)
 
-    # filter data
-    data <- data %>%
-      dplyr::filter(
-        .data$year == .env$start_year,
-        .data$scenario == .env$scenario_selected
-      )
+        # filter data
+        data <- data %>%
+          dplyr::filter(
+            .data$year == .env$start_year,
+            .data$scenario == .env$scenario_selected
+          )
 
-    # map sectors to p4b style
-    # map tech_type and fossil_fuels
-    data <- data %>%
-      # TODO: use input args to define groupings?
-      map_sectors_and_tech_type()
+        # map sectors to p4b style
+        # map tech_type and fossil_fuels
+        data <- data %>%
+          # TODO: use input args to define groupings?
+          map_sectors_and_tech_type()
 
-    # calculate tech_type and sector exposures
-    data_out <- data %>%
-      calculate_exposures() %>%
-      dplyr::select(
-        c("asset_class", "year", "tech_type", "sector", "perc_tech_exposure",
-          "perc_sec_exposure")
-      )
-  }
-  data_out
+        # calculate tech_type and sector exposures
+        data_out <- data %>%
+          calculate_exposures() %>%
+          dplyr::select(
+            c("asset_class", "year", "tech_type", "sector", "perc_tech_exposure",
+              "perc_sec_exposure")
+          )
+      }
+      data_out
+    },
+    error = function (e) {
+      cat("There was an error in prep_green_brown_bars().\nReturning empty plot object.\n")
+      data_out <- empty_plot_error_message()
+    }
+  )
 }
 
 check_data_prep_green_brown_bars <- function(scenario_selected) {

--- a/R/prep_net_zero_commitments.R
+++ b/R/prep_net_zero_commitments.R
@@ -17,24 +17,32 @@ prep_net_zero_commitments <- function(total_portfolio,
                                       peer_group = c("pensionfund", "assetmanager", "bank", "insurance", "other"),
                                       net_zero_targets,
                                       peer_group_share_net_zero) {
-  # match input arg
-  peer_group <- match.arg(peer_group)
+  tryCatch(
+    {
+      # match input arg
+      peer_group <- match.arg(peer_group)
 
-  # calculate portfolio level share of sbti commitments
-  portfolio_share_net_zero <- prep_portfolio_sbti_commitments(
-    total_portfolio = total_portfolio,
-    net_zero_targets = net_zero_targets
+      # calculate portfolio level share of sbti commitments
+      portfolio_share_net_zero <- prep_portfolio_sbti_commitments(
+        total_portfolio = total_portfolio,
+        net_zero_targets = net_zero_targets
+      )
+
+      # get peers sbti commitment for appropriate peer group
+      peer_group_share_net_zero <- peer_group_share_net_zero %>%
+        dplyr::filter(.data$investor_name == .env$peer_group)
+
+      # combin portfolio and peer level results
+      data_out <- portfolio_share_net_zero %>%
+        dplyr::bind_rows(peer_group_share_net_zero)
+
+      return(data_out)
+    },
+    error = function (e) {
+      cat("There was an error in\nprep_net_zero_commitments().\nReturning empty plot object.\n")
+      data_out <- empty_plot_error_message()
+    }
   )
-
-  # get peers sbti commitment for appropriate peer group
-  peer_group_share_net_zero <- peer_group_share_net_zero %>%
-    dplyr::filter(.data$investor_name == .env$peer_group)
-
-  # combin portfolio and peer level results
-  data_out <- portfolio_share_net_zero %>%
-    dplyr::bind_rows(peer_group_share_net_zero)
-
-  return(data_out)
 }
 
 prep_portfolio_sbti_commitments <- function(total_portfolio,

--- a/R/prep_scatter.R
+++ b/R/prep_scatter.R
@@ -17,106 +17,114 @@ prep_scatter <- function(results_portfolio,
                          scenario_source = "GECO2021",
                          scenario_selected = "1.5C-Unif",
                          asset_class = c("equity", "bonds")) {
-  if (is.null(results_portfolio)) {
-    data_out <- use_toy_data("scatter") %>%
-      filter(asset_class == .env$asset_class)
-  } else {
-    # validate inputs
-    asset_class <- match.arg(asset_class)
+  tryCatch(
+    {
+      if (is.null(results_portfolio)) {
+        data_out <- use_toy_data("scatter") %>%
+          filter(asset_class == .env$asset_class)
+      } else {
+        # validate inputs
+        asset_class <- match.arg(asset_class)
 
-    check_data_prep_scatter(
-      asset_class = asset_class,
-      scenario_source = scenario_source,
-      scenario_selected = scenario_selected
-    )
-    
-    portfolio_data_asset <- results_portfolio %>% 
-      filter(asset_class == .env$asset_class)
-    if (nrow(portfolio_data_asset) > 0) {
-      # infer start year
-      start_year <- min(results_portfolio$year, na.rm = TRUE)
-
-      # get scenarios
-      scenario_thresholds <- get("scenario_thresholds")
-
-      scenarios <- scenario_thresholds %>%
-        dplyr::filter(.data$scenario_source == .env$scenario_source) %>%
-        dplyr::pull("scenario")
-
-      # combine input data
-      data <- results_portfolio %>%
-        dplyr::bind_rows(peers_results_aggregated) %>%
-        dplyr::bind_rows(peers_results_individual) %>%
-        dplyr::bind_rows(indices_results_portfolio)
-
-      # filter input data
-      data <- data %>%
-        dplyr::filter(
-          .data$asset_class == .env$asset_class,
-          .data$ald_sector == scatter_sector_lookup
+        check_data_prep_scatter(
+          asset_class = asset_class,
+          scenario_source = scenario_source,
+          scenario_selected = scenario_selected
         )
 
-      # calculate current exposures
-      data_exposure <- data %>%
-        dplyr::filter(
-          .data$year == .env$start_year,
-          .data$scenario == .env$scenario_selected
-        )
+        portfolio_data_asset <- results_portfolio %>%
+          filter(asset_class == .env$asset_class)
+        if (nrow(portfolio_data_asset) > 0) {
+          # infer start year
+          start_year <- min(results_portfolio$year, na.rm = TRUE)
 
-      # map sectors to p4b style
-      # map tech_type and fossil_fuels
-      data_exposure <- data_exposure %>%
-        # TODO: use input args to define groupings?
-        map_sectors_and_tech_type()
+          # get scenarios
+          scenario_thresholds <- get("scenario_thresholds")
 
-      # calculate tech_type and sector exposures
-      data_exposure <- data_exposure %>%
-        calculate_exposures() %>%
-        dplyr::filter(.data$tech_type == "green")
+          scenarios <- scenario_thresholds %>%
+            dplyr::filter(.data$scenario_source == .env$scenario_source) %>%
+            dplyr::pull("scenario")
 
-      # calculate future alignment scores
+          # combine input data
+          data <- results_portfolio %>%
+            dplyr::bind_rows(peers_results_aggregated) %>%
+            dplyr::bind_rows(peers_results_individual) %>%
+            dplyr::bind_rows(indices_results_portfolio)
 
-      # prepare data for sector aggregation
-      data_aggregate_scores <- data %>%
-        wrangle_input_data_aggregate_scores(scenarios = scenarios)
+          # filter input data
+          data <- data %>%
+            dplyr::filter(
+              .data$asset_class == .env$asset_class,
+              .data$ald_sector == scatter_sector_lookup
+            )
 
-      # calculate technology level alignment
-      data_aggregate_scores <- data_aggregate_scores %>%
-        calculate_technology_alignment(
-          start_year = start_year,
-          time_horizon = time_horizon_lookup
-        )
+          # calculate current exposures
+          data_exposure <- data %>%
+            dplyr::filter(
+              .data$year == .env$start_year,
+              .data$scenario == .env$scenario_selected
+            )
 
-      # calculate sectors aggregate score
-      sector_aggregate_scores <- data_aggregate_scores %>%
-        calculate_sector_aggregate_scores()
+          # map sectors to p4b style
+          # map tech_type and fossil_fuels
+          data_exposure <- data_exposure %>%
+            # TODO: use input args to define groupings?
+            map_sectors_and_tech_type()
 
-      sector_aggregate_scores <- sector_aggregate_scores %>%
-        calculate_aggregate_scores_with_scenarios(
-          scenario_thresholds = scenario_thresholds
-        )
+          # calculate tech_type and sector exposures
+          data_exposure <- data_exposure %>%
+            calculate_exposures() %>%
+            dplyr::filter(.data$tech_type == "green")
 
-      # combine outputs and wrangle
-      data_out <- data_exposure %>%
-        dplyr::inner_join(
-          sector_aggregate_scores,
-          by = c(
-            "investor_name", "portfolio_name", "asset_class", "sector",
-            "entity_name", "entity_type", "entity"
-          )
-        ) %>%
-        dplyr::select(
-          c("asset_class", "year", "perc_tech_exposure", "score", "entity_name", "entity_type")
-        ) %>%
-        dplyr::rename(tech_mix_green = "perc_tech_exposure") %>%
-        dplyr::mutate(
-          entity_type = dplyr::if_else(.data$entity_name == "peers_average", "peers_mean", .data$entity_type)
-        )
-    } else {
-      data_out <- toy_data_scatter[0L, ]
+          # calculate future alignment scores
+
+          # prepare data for sector aggregation
+          data_aggregate_scores <- data %>%
+            wrangle_input_data_aggregate_scores(scenarios = scenarios)
+
+          # calculate technology level alignment
+          data_aggregate_scores <- data_aggregate_scores %>%
+            calculate_technology_alignment(
+              start_year = start_year,
+              time_horizon = time_horizon_lookup
+            )
+
+          # calculate sectors aggregate score
+          sector_aggregate_scores <- data_aggregate_scores %>%
+            calculate_sector_aggregate_scores()
+
+          sector_aggregate_scores <- sector_aggregate_scores %>%
+            calculate_aggregate_scores_with_scenarios(
+              scenario_thresholds = scenario_thresholds
+            )
+
+          # combine outputs and wrangle
+          data_out <- data_exposure %>%
+            dplyr::inner_join(
+              sector_aggregate_scores,
+              by = c(
+                "investor_name", "portfolio_name", "asset_class", "sector",
+                "entity_name", "entity_type", "entity"
+              )
+            ) %>%
+            dplyr::select(
+              c("asset_class", "year", "perc_tech_exposure", "score", "entity_name", "entity_type")
+            ) %>%
+            dplyr::rename(tech_mix_green = "perc_tech_exposure") %>%
+            dplyr::mutate(
+              entity_type = dplyr::if_else(.data$entity_name == "peers_average", "peers_mean", .data$entity_type)
+            )
+        } else {
+          data_out <- toy_data_scatter[0L, ]
+        }
+      }
+      data_out
+    },
+    error = function (e) {
+      cat("There was an error in prep_scatter().\nReturning empty plot object.\n")
+      data_out <- empty_plot_error_message()
     }
-  }
-  data_out
+  )
 }
 
 check_data_prep_scatter <- function(asset_class,

--- a/R/prep_scores.R
+++ b/R/prep_scores.R
@@ -20,95 +20,103 @@ prep_scores <- function(results_portfolio,
                         peers_results_aggregated,
                         asset_class = c("equity", "bonds"),
                         scenario_source = "GECO2021") {
-  if (is.null(results_portfolio)) {
-    data_out <- use_toy_data("scores") %>% filter(asset_class == .env$asset_class)
-  } else {
-    # validate inputs
-    asset_class <- match.arg(asset_class)
+  tryCatch(
+    {
+      if (is.null(results_portfolio)) {
+        data_out <- use_toy_data("scores") %>% filter(asset_class == .env$asset_class)
+      } else {
+        # validate inputs
+        asset_class <- match.arg(asset_class)
 
-    check_data_prep_scores(
-      asset_class = asset_class,
-      scenario_source = scenario_source
-    )
-
-    portfolio_data_asset <- results_portfolio %>% 
-      filter(asset_class == .env$asset_class)
-    if (nrow(portfolio_data_asset) > 0) {
-      # infer start_year
-      start_year <- min(results_portfolio$year, na.rm = TRUE)
-
-      # filter selected asset_class
-      data <- results_portfolio %>%
-        dplyr::bind_rows(peers_results_aggregated) %>%
-        dplyr::filter(.data$asset_class == .env$asset_class)
-
-      # get scenarios
-      scenario_thresholds <- get("scenario_thresholds")
-
-      scenarios <- scenario_thresholds %>%
-        dplyr::filter(.data$scenario_source == .env$scenario_source) %>%
-        dplyr::pull("scenario")
-
-      # prepare data for sector aggregation
-      data_aggregate_scores <- data %>%
-        wrangle_input_data_aggregate_scores(scenarios = scenarios)
-
-      # roadmap sectors
-      data_aggregate_scores_tech <- data_aggregate_scores %>%
-        dplyr::filter(.data$ald_sector %in% c("automotive", "coal", "oil", "gas", "power"))
-
-      # calculate technology level alignment
-      data_aggregate_scores_tech <- data_aggregate_scores_tech %>%
-        calculate_technology_alignment(
-          start_year = start_year,
-          time_horizon = time_horizon_lookup
+        check_data_prep_scores(
+          asset_class = asset_class,
+          scenario_source = scenario_source
         )
 
-      # calculate roadmap sectors aggregate score
-      sector_aggregate_scores_tech <- data_aggregate_scores_tech %>%
-        calculate_sector_aggregate_scores()
+        portfolio_data_asset <- results_portfolio %>%
+          filter(asset_class == .env$asset_class)
+        if (nrow(portfolio_data_asset) > 0) {
+          # infer start_year
+          start_year <- min(results_portfolio$year, na.rm = TRUE)
 
-      # emission intensity sectors
-      data_aggregate_scores_emissions <- data_aggregate_scores %>%
-        dplyr::filter(.data$ald_sector %in% c("aviation", "cement", "steel", "shipping"))
+          # filter selected asset_class
+          data <- results_portfolio %>%
+            dplyr::bind_rows(peers_results_aggregated) %>%
+            dplyr::filter(.data$asset_class == .env$asset_class)
 
-      # calculate emission intensity sectors aggregate score
-      sector_aggregate_scores_emissions <- data_aggregate_scores_emissions %>%
-        calculate_emissions_sectors_aggregate_scores(
-          start_year = start_year,
-          time_horizon = time_horizon_lookup
-        )
+          # get scenarios
+          scenario_thresholds <- get("scenario_thresholds")
 
-      # combine scores of roadmap and emission intensity sectors
-      sector_aggregate_scores <- sector_aggregate_scores_tech %>%
-        dplyr::bind_rows(sector_aggregate_scores_emissions)
+          scenarios <- scenario_thresholds %>%
+            dplyr::filter(.data$scenario_source == .env$scenario_source) %>%
+            dplyr::pull("scenario")
 
-      # get remaining carbon budgets and calculate portfolio aggregate score
-      remaining_carbon_budgets <- get("remaining_carbon_budgets")
+          # prepare data for sector aggregation
+          data_aggregate_scores <- data %>%
+            wrangle_input_data_aggregate_scores(scenarios = scenarios)
 
-      portfolio_aggregate_scores <- sector_aggregate_scores %>%
-        calculate_portfolio_aggregate_scores(
-          remaining_carbon_budgets = remaining_carbon_budgets
-        )
+          # roadmap sectors
+          data_aggregate_scores_tech <- data_aggregate_scores %>%
+            dplyr::filter(.data$ald_sector %in% c("automotive", "coal", "oil", "gas", "power"))
 
-      # combine scores in single data frame
-      output_scores <- sector_aggregate_scores %>%
-        dplyr::bind_rows(portfolio_aggregate_scores) %>%
-        dplyr::select(-"sector_exposure")
+          # calculate technology level alignment
+          data_aggregate_scores_tech <- data_aggregate_scores_tech %>%
+            calculate_technology_alignment(
+              start_year = start_year,
+              time_horizon = time_horizon_lookup
+            )
 
-      # apply scenario based grades
-      data_out <- output_scores %>%
-        calculate_aggregate_scores_with_scenarios(
-          scenario_thresholds = scenario_thresholds
-        ) %>%
-        dplyr::select(
-          c("asset_class", "scope", "entity", "sector", "score")
-        )
-    } else {
-      data_out <- toy_data_scores[0L, ]
+          # calculate roadmap sectors aggregate score
+          sector_aggregate_scores_tech <- data_aggregate_scores_tech %>%
+            calculate_sector_aggregate_scores()
+
+          # emission intensity sectors
+          data_aggregate_scores_emissions <- data_aggregate_scores %>%
+            dplyr::filter(.data$ald_sector %in% c("aviation", "cement", "steel", "shipping"))
+
+          # calculate emission intensity sectors aggregate score
+          sector_aggregate_scores_emissions <- data_aggregate_scores_emissions %>%
+            calculate_emissions_sectors_aggregate_scores(
+              start_year = start_year,
+              time_horizon = time_horizon_lookup
+            )
+
+          # combine scores of roadmap and emission intensity sectors
+          sector_aggregate_scores <- sector_aggregate_scores_tech %>%
+            dplyr::bind_rows(sector_aggregate_scores_emissions)
+
+          # get remaining carbon budgets and calculate portfolio aggregate score
+          remaining_carbon_budgets <- get("remaining_carbon_budgets")
+
+          portfolio_aggregate_scores <- sector_aggregate_scores %>%
+            calculate_portfolio_aggregate_scores(
+              remaining_carbon_budgets = remaining_carbon_budgets
+            )
+
+          # combine scores in single data frame
+          output_scores <- sector_aggregate_scores %>%
+            dplyr::bind_rows(portfolio_aggregate_scores) %>%
+            dplyr::select(-"sector_exposure")
+
+          # apply scenario based grades
+          data_out <- output_scores %>%
+            calculate_aggregate_scores_with_scenarios(
+              scenario_thresholds = scenario_thresholds
+            ) %>%
+            dplyr::select(
+              c("asset_class", "scope", "entity", "sector", "score")
+            )
+        } else {
+          data_out <- toy_data_scores[0L, ]
+        }
+      }
+      data_out
+    },
+    error = function (e) {
+      cat("There was an error in prep_scores().\nReturning empty plot object.\n")
+      data_out <- empty_plot_error_message()
     }
-  }
-  data_out
+  )
 }
 
 check_data_prep_scores <- function(scenario_source,

--- a/R/prep_scores_scorecard.R
+++ b/R/prep_scores_scorecard.R
@@ -16,34 +16,42 @@
 #' @export
 prep_scores_scorecard <- function(results_portfolio,
                                   scenario_source = "GECO2021") {
-  if (is.null(results_portfolio)) {
-    data_out <- use_toy_data("scores") %>% filter(
-      .data$scope == "portfolio",
-      .data$entity == "this_portfolio"
-    )
-  } else {
-    empty_peers_results_aggregated <- tibble::tibble()
+  tryCatch(
+    {
+      if (is.null(results_portfolio)) {
+        data_out <- use_toy_data("scores") %>% filter(
+          .data$scope == "portfolio",
+          .data$entity == "this_portfolio"
+        )
+      } else {
+        empty_peers_results_aggregated <- tibble::tibble()
 
-    # input checks are automatically carried out when calling prep_scores()
-    data_equity <- results_portfolio %>%
-      prep_scores(
-        peers_results_aggregated = empty_peers_results_aggregated,
-        asset_class = "equity",
-        scenario_source = scenario_source
-      )
-    data_bonds <- results_portfolio %>%
-      prep_scores(
-        peers_results_aggregated = empty_peers_results_aggregated,
-        asset_class = "bonds",
-        scenario_source = scenario_source
-      )
+        # input checks are automatically carried out when calling prep_scores()
+        data_equity <- results_portfolio %>%
+          prep_scores(
+            peers_results_aggregated = empty_peers_results_aggregated,
+            asset_class = "equity",
+            scenario_source = scenario_source
+          )
+        data_bonds <- results_portfolio %>%
+          prep_scores(
+            peers_results_aggregated = empty_peers_results_aggregated,
+            asset_class = "bonds",
+            scenario_source = scenario_source
+          )
 
-    data_out <- data_equity %>%
-      rbind(data_bonds) %>%
-      dplyr::filter(
-        .data$scope == "portfolio",
-        .data$entity == "this_portfolio"
-      )
-  }
-  data_out
+        data_out <- data_equity %>%
+          rbind(data_bonds) %>%
+          dplyr::filter(
+            .data$scope == "portfolio",
+            .data$entity == "this_portfolio"
+          )
+      }
+      data_out
+    },
+    error = function (e) {
+      cat("There was an error in prep_diagram().\nReturning empty plot object.\n")
+      data_out <- empty_plot_error_message()
+    }
+  )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -120,3 +120,16 @@ empty_plot_no_data_message <- function() {
     theme_void()
   p
 }
+
+empty_plot_error_message <- function() {
+  p <- ggplot() +
+    annotate(
+      "text",
+      label = "An error occured\ncreating this plot",
+      x = 1,
+      y = 1,
+      size = 10
+    ) +
+    theme_void()
+  p
+}


### PR DESCRIPTION
closes #121 

- tryCatch handling for each `prep_*()` and `plot_*()` function, that return empty plot objects with an error text
- not handling `prep_data_executive_summary()` in this PR, I think this needs to be done differently
- prep functions that error will return a plot object (as discussed with @MonikaFu .. this may not directly be intuitive, but as it will be stored in an object and that object passed to the plot function which will then also fail and display the empty plot. but really I think the error in `prep_*` functions could return any object that would certainly make the ensuing plot_`*` fail
- please comment on the implementation, I am by no means sure this is the best way to do it

