### PR TITLE
Handle plot errors in rmd

### DIFF
--- a/R/render_executive_summary.R
+++ b/R/render_executive_summary.R
@@ -15,6 +15,7 @@
 #' @param total_portfolio Data frame that contains the total portfolio as found in the standard PACTA processed inputs file "total_portfolio.rds"
 #' @param scenario_selected Character single string specifying the selected scenario, e.g. "1.5C-Unif"
 #' @param currency_exchange_value Numeric single numeric value specifying the exchange rate from USD into the desired display currency, e.g. `1.03`
+#' @param log_dir Character single, valid filepath to a directory that will contain the log file
 #'
 #' @return a pdf document written to output_dir
 #' @export

--- a/R/render_executive_summary.R
+++ b/R/render_executive_summary.R
@@ -33,7 +33,8 @@ render_executive_summary <- function(data,
                                      peer_group,
                                      total_portfolio,
                                      scenario_selected,
-                                     currency_exchange_value) {
+                                     currency_exchange_value,
+                                     log_dir) {
   render(
     input = file.path(exec_summary_dir, file_name),
     output_dir = output_dir,
@@ -56,7 +57,8 @@ render_executive_summary <- function(data,
       peers_results_aggregated = data$peers_results_aggregated,
       peers_results_individual = data$peers_results_individual,
       indices_results_portfolio = data$indices_results_portfolio,
-      currency_exchange_value = currency_exchange_value
+      currency_exchange_value = currency_exchange_value,
+      log_dir = log_dir
     )
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -120,3 +120,16 @@ empty_plot_no_data_message <- function() {
     theme_void()
   p
 }
+
+empty_plot_error_message <- function() {
+  p <- ggplot() +
+    annotate(
+      "text",
+      label = "An error occured\ncreating this plot",
+      x = 1,
+      y = 1,
+      size = 10
+    ) +
+    theme_void()
+  p
+}

--- a/inst/extdata/PA2022CH_en_exec_summary/template.Rmd
+++ b/inst/extdata/PA2022CH_en_exec_summary/template.Rmd
@@ -722,7 +722,7 @@ CO_2_ intensity according to GEAK classes (Means of the participant)
 
 ```{r real_estate_score_text, eval = real_estate_flag}
 cat("Directly held buildings: 12.5 kg/m2 -> D ")
-cat(Mortgages: 25.1 kg/m2 -> G")
+cat("Mortgages: 25.1 kg/m2 -> G")
 ```
 
 

--- a/inst/extdata/PA2022CH_en_exec_summary/template.Rmd
+++ b/inst/extdata/PA2022CH_en_exec_summary/template.Rmd
@@ -22,6 +22,7 @@ params:
   peers_results_individual: NULL
   indices_results_portfolio: NULL
   currency_exchange_value: NULL
+  log_dir: NULL
 ---
 
 ```{r setup, include=FALSE}
@@ -36,6 +37,7 @@ portfolio_name <- params$portfolio_name
 peer_group <- params$peer_group
 scenario_selected <- params$scenario_selected
 currency_exchange_value <- params$currency_exchange_value
+log_dir <- params$log_dir
 
 results_portfolio <- params$results_portfolio
 peers_results_individual <- params$peers_results_individual
@@ -105,11 +107,23 @@ The analysis of the listed equity and corporate bond portfolios covers 8 climate
 The trajectory alignment measurement was done using the PACTA method. PACTA compares forward-looking production plans of all invested companies in the PACTA sectors on a technology level to the targets from climate scenarios. For more information on the PACTA methodology, please refer to [https://rmi.gitbook.io/pacta-knowledge-hub/](https://rmi.gitbook.io/pacta-knowledge-hub/).
 
 ```{r diagram, fig.width=8, fig.height=2}
-data_diagram <- prep_diagram(
-  audit_data = audit_data,
-  emissions_data = emissions_data
+tryCatch(
+  {
+    data_diagram <- prep_diagram(
+      audit_data = audit_data,
+      emissions_data = emissions_data
+    )
+    plot_diagram(data_diagram)
+  },
+  error = function(e) {
+    pacta.portfolio.analysis:::write_log(
+      "ES: There was an error in prep/plot_diagram(). Returning empty plot object.\n",
+      file_path = log_dir
+    )
+    empty_plot_error_message()
+  }
 )
-plot_diagram(data_diagram)
+
 ```
 
 \* coal mining, oil & gas extraction, power, auto, cement, steel and aviation
@@ -125,19 +139,42 @@ plot_diagram(data_diagram)
 The chart provides information on the exposure to the PACTA sectors. Fossil fuels (extraction) is shown aggregated as well as disaggregated for peer- and index-comparison.
 
 ```{r exposure, fig.show='hold', out.width='50%'}
-data_green_brown_bars <- prep_green_brown_bars(
-  results_portfolio = results_portfolio,
-  scenario_selected = scenario_selected
+tryCatch(
+  {
+    data_green_brown_bars <- prep_green_brown_bars(
+      results_portfolio = results_portfolio,
+      scenario_selected = scenario_selected
+    )
+    plot_green_brown_bars(data_green_brown_bars)
+  },
+  error = function(e) {
+    pacta.portfolio.analysis:::write_log(
+      "ES: There was an error in prep/plot_green_brown_bars(). Returning empty plot object.\n",
+      file_path = log_dir
+    )
+    empty_plot_error_message()
+  }
 )
-plot_green_brown_bars(data_green_brown_bars)
 
-data_fossil_bars <- prep_fossil_bars(
-  results_portfolio = results_portfolio,
-  peers_results_aggregated = peers_results_aggregated,
-  indices_results_portfolio = indices_results_portfolio,
-  scenario_selected = scenario_selected
+tryCatch(
+  {
+    data_fossil_bars <- prep_fossil_bars(
+      results_portfolio = results_portfolio,
+      peers_results_aggregated = peers_results_aggregated,
+      indices_results_portfolio = indices_results_portfolio,
+      scenario_selected = scenario_selected
+    )
+    plot_fossil_bars(data_fossil_bars)
+  },
+  error = function(e) {
+    pacta.portfolio.analysis:::write_log(
+      "ES: There was an error in prep/plot_fossil_bars(). Returning empty plot object.\n",
+      file_path = log_dir
+    )
+    empty_plot_error_message()
+  }
 )
-plot_fossil_bars(data_fossil_bars)
+
 ```
 
 \* exposure to companies with main activity in PACTA sectors
@@ -151,43 +188,66 @@ plot_fossil_bars(data_fossil_bars)
 The chart below shows the current low-carbon exposure and the forward-looking climate scenario alignment in the power sector for you and your peers. The current exposure to low-carbon technologies in the power sector increases right-wards, while the alignment improves upwards. A significant increase in renewable energy capacity will be required to achieve a 1.5°C climate scenario, so even companies with a high current share of low-carbon technologies will need to build new capacity in order to be aligned in the future. A current high low-carbon share and a low future alignment would therefore indicate a lack of planned renewables investment.
 
 ```{r scatter, fig.show="hold", out.width="50%"}
-data_scatter_power_b <- prep_scatter(
-  results_portfolio = results_portfolio,
-  peers_results_aggregated = peers_results_aggregated,
-  peers_results_individual = peers_results_individual,
-  indices_results_portfolio = indices_results_portfolio,
-  scenario_selected = scenario_selected,
-  asset_class = "bonds"
+
+tryCatch(
+  {
+    data_scatter_power_b <- prep_scatter(
+      results_portfolio = results_portfolio,
+      peers_results_aggregated = peers_results_aggregated,
+      peers_results_individual = peers_results_individual,
+      indices_results_portfolio = indices_results_portfolio,
+      scenario_selected = scenario_selected,
+      asset_class = "bonds"
+    )
+
+    all_entity_types <- length(unique(data_scatter_power_b$entity_type)) == 4
+
+    if (all_entity_types | nrow(data_scatter_power_b) == 0) {
+      plot_scatter(data_scatter_power_b) +
+        patchwork::plot_annotation(
+          title = "Bonds",
+          theme = theme(plot.title = element_text(face = "bold", hjust = 0.5, size = 22))
+        )
+    }
+  },
+  error = function(e) {
+    pacta.portfolio.analysis:::write_log(
+      "ES: There was an error in prep/plot_scatter() for bonds. Returning empty plot object.\n",
+      file_path = log_dir
+    )
+    empty_plot_error_message()
+  }
 )
 
-all_entity_types <- length(unique(data_scatter_power_b$entity_type)) == 4
-
-if (all_entity_types | nrow(data_scatter_power_b) == 0) {
-  plot_scatter(data_scatter_power_b) +
-    patchwork::plot_annotation(
-      title = "Bonds",
-      theme = theme(plot.title = element_text(face = "bold", hjust = 0.5, size = 22))
+tryCatch(
+  {
+    data_scatter_power_e <- prep_scatter(
+      results_portfolio = results_portfolio,
+      peers_results_aggregated = peers_results_aggregated,
+      peers_results_individual = peers_results_individual,
+      indices_results_portfolio = indices_results_portfolio,
+      scenario_selected = scenario_selected,
+      asset_class = "equity"
     )
-}
 
-data_scatter_power_e <- prep_scatter(
-  results_portfolio = results_portfolio,
-  peers_results_aggregated = peers_results_aggregated,
-  peers_results_individual = peers_results_individual,
-  indices_results_portfolio = indices_results_portfolio,
-  scenario_selected = scenario_selected,
-  asset_class = "equity"
+    all_entity_types <- length(unique(data_scatter_power_e$entity_type)) == 4
+
+    if (all_entity_types | nrow(data_scatter_power_e) == 0) {
+      plot_scatter(data_scatter_power_e) +
+        patchwork::plot_annotation(
+          title = "Equity",
+          theme = theme(plot.title = element_text(face = "bold", hjust = 0.5, size = 22))
+        )
+    }
+  },
+  error = function(e) {
+    pacta.portfolio.analysis:::write_log(
+      "ES: There was an error in prep/plot_scatter() for equity. Returning empty plot object.\n",
+      file_path = log_dir
+    )
+    empty_plot_error_message()
+  }
 )
-
-all_entity_types <- length(unique(data_scatter_power_e$entity_type)) == 4
-
-if (all_entity_types | nrow(data_scatter_power_e) == 0) {
-  plot_scatter(data_scatter_power_e) +
-    patchwork::plot_annotation(
-      title = "Equity",
-      theme = theme(plot.title = element_text(face = "bold", hjust = 0.5, size = 22))
-    )
-}
 ```
 
 ### Future (Other PACTA sectors)
@@ -197,27 +257,49 @@ if (all_entity_types | nrow(data_scatter_power_e) == 0) {
 The aggregated score compares the alignment of all assets until 2026 to the GECO 2021 Scenario. The score is calculated both on aggregate portfolio level (see also Climate Scores) and per PACTA sector (except for cement which is not covered in GECO2021).
 
 ```{r scores, fig.show='hold', out.width='50%'}
-data_scores_b <- prep_scores(
-  results_portfolio = results_portfolio,
-  peers_results_aggregated = peers_results_aggregated,
-  asset_class = "bonds"
-)
-plot_scores(data_scores_b) +
-  patchwork::plot_annotation(
-    title = "Bonds",
-    theme = theme(plot.title = element_text(face = "bold", hjust = 0.5, size = 22))
+tryCatch(
+  {
+    data_scores_b <- prep_scores(
+      results_portfolio = results_portfolio,
+      peers_results_aggregated = peers_results_aggregated,
+      asset_class = "bonds"
     )
+    plot_scores(data_scores_b) +
+      patchwork::plot_annotation(
+        title = "Bonds",
+        theme = theme(plot.title = element_text(face = "bold", hjust = 0.5, size = 22))
+      )
+  },
+  error = function(e) {
+    pacta.portfolio.analysis:::write_log(
+      "ES: There was an error in prep/plot_scores(). Returning empty plot object.\n",
+      file_path = log_dir
+    )
+    empty_plot_error_message()
+  }
+)
 
-data_scores_e <- prep_scores(
-  results_portfolio = results_portfolio,
-  peers_results_aggregated = peers_results_aggregated,
-  asset_class = "equity"
-)
-plot_scores(data_scores_e) +
-  patchwork::plot_annotation(
-    title = "Equity",
-    theme = theme(plot.title = element_text(face = "bold", hjust = 0.5, size = 22))
+tryCatch(
+  {
+    data_scores_e <- prep_scores(
+      results_portfolio = results_portfolio,
+      peers_results_aggregated = peers_results_aggregated,
+      asset_class = "equity"
     )
+    plot_scores(data_scores_e) +
+      patchwork::plot_annotation(
+        title = "Equity",
+        theme = theme(plot.title = element_text(face = "bold", hjust = 0.5, size = 22))
+      )
+  },
+  error = function(e) {
+    pacta.portfolio.analysis:::write_log(
+      "ES: There was an error in prep/plot_scores(). Returning empty plot object.\n",
+      file_path = log_dir
+    )
+    empty_plot_error_message()
+  }
+)
 ```
 
 \newpage
@@ -234,23 +316,45 @@ To learn more about how the alignment of your portfolio evolves over the next fi
 
 
 ```{r alignment_table_bonds, fig.height=5, fig.width=6}
-data_alignment_table <- prep_alignment_table(
-  results_portfolio = results_portfolio, 
-  peers_results_aggregated = peers_results_aggregated,
-  asset_class = "bonds"
+tryCatch(
+  {
+    data_alignment_table <- prep_alignment_table(
+      results_portfolio = results_portfolio, 
+      peers_results_aggregated = peers_results_aggregated,
+      asset_class = "bonds"
+    )
+    plot_alignment_table(data_alignment_table)
+  },
+  error = function(e) {
+    pacta.portfolio.analysis:::write_log(
+      "ES: There was an error in prep/plot_alignment_table() for bonds. Returning empty plot object.\n",
+      file_path = log_dir
+    )
+    empty_plot_error_message()
+  }
 )
-plot_alignment_table(data_alignment_table)
 # TODO: add title
 ```
 
 
 ```{r alignment_table_equity, fig.height=5, fig.width=6}
-data_alignment_table <- prep_alignment_table(
-  results_portfolio = results_portfolio, 
-  peers_results_aggregated = peers_results_aggregated,
-  asset_class = "equity"
+tryCatch(
+  {
+    data_alignment_table <- prep_alignment_table(
+      results_portfolio = results_portfolio, 
+      peers_results_aggregated = peers_results_aggregated,
+      asset_class = "equity"
+    )
+    plot_alignment_table(data_alignment_table)
+  },
+  error = function(e) {
+    pacta.portfolio.analysis:::write_log(
+      "ES: There was an error in prep/plot_alignment_table() for equity. Returning empty plot object.\n",
+      file_path = log_dir
+    )
+    empty_plot_error_message()
+  }
 )
-plot_alignment_table(data_alignment_table)
 # TODO: add title
 ```
 
@@ -353,7 +457,7 @@ This layer chart is shown for coal on the one hand and oil and gas on the other 
 ## Annex (III): Explanation of Charts
 
 ```{r real_estate_explanations, child="real-estate-explanations.Rmd", eval = real_estate_flag}
-
+```
 \newpage
 
 ## Annex (IV): FAQs
@@ -410,13 +514,25 @@ The following three pages of the “Climate Scores” complement the PACTA Execu
 All sources of carbon emissions from invested companies (scope 1-3) are included in the estimation.
 
 ```{r emissions_scorecard}
-# the specific PACTA outputs that we need here are my guesses 
-data_emissions_scorecard <- prep_emissions_scorecard(
-  emissions_data = emissions_data,
-  audit_data = audit_data,
-  currency_exchange_value = currency_exchange_value
+tryCatch(
+  {
+    data_emissions_scorecard <- prep_emissions_scorecard(
+      emissions_data = emissions_data,
+      audit_data = audit_data,
+      currency_exchange_value = currency_exchange_value
+    )
+    plot_emissions_scorecard(data_emissions_scorecard)
+  },
+  error = function(e) {
+    pacta.portfolio.analysis:::write_log(
+      "ES: There was an error in prep/plot_emissions_scorecard(). Returning empty plot object.\n",
+      file_path = log_dir
+    )
+    empty_plot_error_message()
+  }
 )
-plot_emissions_scorecard(data_emissions_scorecard)
+
+
 ```
 
 ```{r emissions_scorecard_info}
@@ -459,9 +575,19 @@ There is scientific consensus on the need to phase-out coal, stop financing new 
 
 ```{r exposures_scorecard, eval = FALSE}
 # FIXME: turn eval back on
-# the specific PACTA outputs that we need here are my guesses 
-data_exposures_scorecard <- prep_exposures_scorecard(results_portfolio)
-plot_exposures_scorecard(data_exposures_scorecard)
+tryCatch(
+  {
+    data_exposures_scorecard <- prep_exposures_scorecard(results_portfolio)
+    plot_exposures_scorecard(data_exposures_scorecard)
+  },
+  error = function(e) {
+    pacta.portfolio.analysis:::write_log(
+      "ES: There was an error in prep/plot_exposures_scorecard(). Returning empty plot object.\n",
+      file_path = log_dir
+    )
+    empty_plot_error_message()
+  }
+)
 ```
 
 ### Transition to Net zero
@@ -470,9 +596,19 @@ plot_exposures_scorecard(data_exposures_scorecard)
 
 ```{r scores_scorecard, eval = FALSE}
 # FIXME: turn eval back on
-# the specific PACTA outputs that we need here are my guesses 
-data_scores_scorecard <- prep_scores_scorecard(results_portfolio)
-plot_scores_scorecard(data_scores_scorecard)
+tryCatch(
+  {
+    data_scores_scorecard <- prep_scores_scorecard(results_portfolio)
+    plot_scores_scorecard(data_scores_scorecard)
+  },
+  error = function(e) {
+    pacta.portfolio.analysis:::write_log(
+      "ES: There was an error in prep/plot_scores_scorecard(). Returning empty plot object.\n",
+      file_path = log_dir
+    )
+    empty_plot_error_message()
+  }
+)
 
 # TODO: needs to return actual scenario name
 ```

--- a/inst/extdata/PA2022CH_en_exec_summary/template.Rmd
+++ b/inst/extdata/PA2022CH_en_exec_summary/template.Rmd
@@ -682,27 +682,41 @@ data_prep_net_zero_commitments <- prep_net_zero_commitments(
 # FIXME: Enable
 if (real_estate_flag){
 
-  real_estate_data <- jsonlite::read_json(
-    path = file.path(real_estate_dir, "data", "data.json")
-    )[["exec_sum"]]
-
-  re_data_scores_scorecard <- tibble(
-    asset_class = c("directly held", "mortgages"),
-    score = c(
-      real_estate_data[["real_estate"]][["co2eq_emissions_grade"]],
-      real_estate_data[["mortgage"]][["co2eq_emissions_grade"]]
-    )
-    ) %>%
-  dplyr::mutate(score = dplyr::if_else(score %in% LETTERS[6:28], "E", score))
-
-  # FIXME: make a plot_scores_scorecards that allows ratings through "G"
-  plot_scores_scorecard(
-    data = re_data_scores_scorecard,
-    facet = c("directly held", "mortgages")
+  tryCatch(
+   {
+      real_estate_data <- jsonlite::read_json(
+        path = file.path(real_estate_dir, "data", "data.json")
+        )[["exec_sum"]]
+    
+      re_data_scores_scorecard <- tibble(
+        asset_class = c("directly held", "mortgages"),
+        score = c(
+          real_estate_data[["real_estate"]][["co2eq_emissions_grade"]],
+          real_estate_data[["mortgage"]][["co2eq_emissions_grade"]]
+        )
+        ) %>%
+      dplyr::mutate(score = dplyr::if_else(score %in% LETTERS[6:28], "E", score))
+      
+      # FIXME: make a plot_scores_scorecards that allows ratings through "G"
+      plot_scores_scorecard(
+        data = re_data_scores_scorecard,
+        facet = c("directly held", "mortgages")
+      )
+    },
+    error = function(e) {
+      pacta.portfolio.analysis:::write_log(
+        "ES: There was an error in prep/plot_scores_scorecard(). Returning empty plot object.\n",
+        file_path = log_dir
+      )
+      empty_plot_error_message()
+    }
   )
 } else {
   empty_plot_no_data_message()
 }
+
+  
+  
 ```
 
 #### General Info

--- a/inst/extdata/PA2022CH_en_exec_summary/template.Rmd
+++ b/inst/extdata/PA2022CH_en_exec_summary/template.Rmd
@@ -442,7 +442,7 @@ Chart_sample 6
 
 This dart charts shows which engagement actions your institution is practicing, accoding to your answers. It starts with a general engagement policy, which can be improved in effectiveness through a dedicated engagement team and finally through joint engagement with other institutions. Best practice is when all three levels are covered.
 The chart is shown separately for fossil fuels, automotive, and power sector as these (i) are considered as the most climate relevant sectors and (ii) have low-carbon substitutes which allows investors to support the shift to existing technologies. 
-Considering joint engagement as a way to increase the efficacy of engagement practices is echoed by literature on the topic and supported by, for example, the NZAOA **(Link to report here)**. 
+Considering joint engagement as a way to increase the efficacy of engagement practices is echoed by literature on the topic and supported by, for example, the NZAOA (Link to report [here](https://www.unepfi.org/wordpress/wp-content/uploads/2022/03/NZAOA_The-future-of-investor-engagement.pdf)). 
 
 
 ### Dart chart: negative screening in oil and gas as well as coal sector
@@ -573,8 +573,7 @@ Portfolio assets covered by assessment: **`r round(total_portfolio_percentage_co
 There is scientific consensus on the need to phase-out coal, stop financing new fossil fuel projects, and to increase renewable power capacity. Below figure shows the financial exposure (as AUM in %) of this portfolio to technologies in the industries coal mining, oil and gas upstream, fossil fuel power production, and renewable power production. The PACTA exposure is based on production capacities and not on revenues. 
 
 
-```{r exposures_scorecard, eval = FALSE}
-# FIXME: turn eval back on
+```{r exposures_scorecard}
 tryCatch(
   {
     data_exposures_scorecard <- prep_exposures_scorecard(results_portfolio)
@@ -594,8 +593,9 @@ tryCatch(
 
 #### PACTA Aggregated Climate Alignment Score
 
-```{r scores_scorecard, eval = FALSE}
-# FIXME: turn eval back on
+</br>
+
+```{r scores_scorecard}
 tryCatch(
   {
     data_scores_scorecard <- prep_scores_scorecard(results_portfolio)
@@ -676,10 +676,16 @@ data_prep_net_zero_commitments <- prep_net_zero_commitments(
 
 ```
 
+* Share of companies in portfolio with verified commitments to net-zero and credible near term targets: **`r round(data_prep_net_zero_commitments %>% dplyr::filter(.data$portfolio_name == "this_portfolio") %>% dplyr::pull("share_net_zero") * 100, 1)` %**
+
+* Average share of companies in peer portfolios with verified commitments to net-zero and credible interim targets: **`r round(data_prep_net_zero_commitments %>% dplyr::filter(.data$portfolio_name == peer_group) %>% dplyr::pull("share_net_zero") * 100, 1)` %**
+
+
 #### Real Estate Score
 
-```{r real_estate_scores_scorecard, eval = FALSE}
-# FIXME: Enable
+</br>
+
+```{r real_estate_scores_scorecard}
 if (real_estate_flag){
 
   tryCatch(
@@ -719,20 +725,10 @@ if (real_estate_flag){
   
 ```
 
-#### General Info
-
-```{r general_info, fig.height = 6}
-# TODO: add % emissions covered by assessment
-
-```
-
-* Share of companies in portfolio with verified commitments to net-zero and credible near term targets: **`r round(data_prep_net_zero_commitments %>% dplyr::filter(.data$portfolio_name == "this_portfolio") %>% dplyr::pull("share_net_zero") * 100, 1)` %**
-
-* Average share of companies in peer portfolios with verified commitments to net-zero and credible interim targets: **`r round(data_prep_net_zero_commitments %>% dplyr::filter(.data$portfolio_name == peer_group) %>% dplyr::pull("share_net_zero") * 100, 1)` %**
 
 ### Swiss real estate and mortgages
 
-CO_2_ intensity according to GEAK classes (Means of the participant)
+CO~2~ intensity according to GEAK classes (Means of the participant)
 
 ```{r real_estate_score_text, eval = real_estate_flag}
 cat("Directly held buildings: 12.5 kg/m2 -> D ")

--- a/inst/extdata/PA2022CH_en_exec_summary/template.Rmd
+++ b/inst/extdata/PA2022CH_en_exec_summary/template.Rmd
@@ -609,8 +609,6 @@ tryCatch(
     empty_plot_error_message()
   }
 )
-
-# TODO: needs to return actual scenario name
 ```
 
 This score represents the estimated aggregate alignment of the PACTA sectors (except for cement) in the portfolio with respect to the GECO 2021 scenarios. Please bear in mind that the interpretation of this score should be accompanied by an analysis of the underlying results and investment strategy used in each one of the analysed sectors, given the assumptions that an aggregated metric is based on. Some portfolios with climate objectives may intentionally include investments in companies that are not yet on track to achieve 1.5°C alignment, seeking instead to contribute actively to climate goals by improving the alignment of investee companies to bring a larger share of the economy into alignment over time. The combined set of indicators above and their display are considered by the Swiss government to represent the current best-practice in providing science-based transparency on the alignment of portfolio assets with global climate goals.

--- a/inst/extdata/PA2022CH_en_exec_summary/template.Rmd
+++ b/inst/extdata/PA2022CH_en_exec_summary/template.Rmd
@@ -722,7 +722,7 @@ CO_2_ intensity according to GEAK classes (Means of the participant)
 
 ```{r real_estate_score_text, eval = real_estate_flag}
 cat("Directly held buildings: 12.5 kg/m2 -> D ")
-cat(Mortgages: 25.1 kg/m2 -> G"
+cat(Mortgages: 25.1 kg/m2 -> G")
 ```
 
 

--- a/man/render_executive_summary.Rd
+++ b/man/render_executive_summary.Rd
@@ -19,7 +19,8 @@ render_executive_summary(
   peer_group,
   total_portfolio,
   scenario_selected,
-  currency_exchange_value
+  currency_exchange_value,
+  log_dir
 )
 }
 \arguments{

--- a/man/render_executive_summary.Rd
+++ b/man/render_executive_summary.Rd
@@ -53,6 +53,8 @@ render_executive_summary(
 \item{scenario_selected}{Character single string specifying the selected scenario, e.g. "1.5C-Unif"}
 
 \item{currency_exchange_value}{Numeric single numeric value specifying the exchange rate from USD into the desired display currency, e.g. \code{1.03}}
+
+\item{log_dir}{Character single, valid filepath to a directory that will contain the log file}
 }
 \value{
 a pdf document written to output_dir


### PR DESCRIPTION
closes #121 
relates to https://github.com/RMI-PACTA/workflow.transition.monitor/pull/78

- handles plot errors
  - returns empty plot with text
  - writes error message to log file
- corrects output structure in scorecard section
- fixes mistake in cat() in scorecard
- adds link to annex that was missing
- reactivates some functional code bits