### PR TITLE
Revert "use the `use_toy_data()` util function to load toy datasets"

### DIFF
--- a/R/prep_alignment_table.R
+++ b/R/prep_alignment_table.R
@@ -27,7 +27,7 @@ prep_alignment_table <- function(results_portfolio,
     match.arg(asset_class)
     check_data_prep_alignment_table(scenario_source = scenario_source)
 
-    portfolio_data_asset <- results_portfolio %>%
+    portfolio_data_asset <- results_portfolio %>% 
       filter(asset_class == .env$asset_class)
     if (nrow(portfolio_data_asset) > 0) {
       # infer start_year
@@ -94,9 +94,9 @@ prep_alignment_table <- function(results_portfolio,
       ) %>%
       filter(.data$asset_class == .env$asset_class)
     } else {
-      data_out <- use_toy_data("alignment_table")[0L, ]
+      data_out <- toy_data_alignment_table[0L, ]
     }
-  }
+  } 
   data_out
 }
 

--- a/R/prep_scatter.R
+++ b/R/prep_scatter.R
@@ -29,8 +29,8 @@ prep_scatter <- function(results_portfolio,
       scenario_source = scenario_source,
       scenario_selected = scenario_selected
     )
-
-    portfolio_data_asset <- results_portfolio %>%
+    
+    portfolio_data_asset <- results_portfolio %>% 
       filter(asset_class == .env$asset_class)
     if (nrow(portfolio_data_asset) > 0) {
       # infer start year
@@ -113,7 +113,7 @@ prep_scatter <- function(results_portfolio,
           entity_type = dplyr::if_else(.data$entity_name == "peers_average", "peers_mean", .data$entity_type)
         )
     } else {
-      data_out <- use_toy_data("scatter")[0L, ]
+      data_out <- toy_data_scatter[0L, ]
     }
   }
   data_out

--- a/R/prep_scores.R
+++ b/R/prep_scores.R
@@ -31,7 +31,7 @@ prep_scores <- function(results_portfolio,
       scenario_source = scenario_source
     )
 
-    portfolio_data_asset <- results_portfolio %>%
+    portfolio_data_asset <- results_portfolio %>% 
       filter(asset_class == .env$asset_class)
     if (nrow(portfolio_data_asset) > 0) {
       # infer start_year
@@ -105,7 +105,7 @@ prep_scores <- function(results_portfolio,
           c("asset_class", "scope", "entity", "sector", "score")
         )
     } else {
-      data_out <- use_toy_data("scores")[0L, ]
+      data_out <- toy_data_scores[0L, ]
     }
   }
   data_out


### PR DESCRIPTION
Since `use_toy_data()` automatically triggers a warning message, using this function as a utility will clutter the console with unnecessary warnings. 

Reverts RMI-PACTA/pacta.executive.summary#117