### PR TITLE
`prep_scatter` now considers sector-wise exposure (rather than full portfolio exposure)

### DIFF
--- a/R/prep_green_brown_bars.R
+++ b/R/prep_green_brown_bars.R
@@ -99,14 +99,15 @@ calculate_exposures <- function(data) {
       .data$entity_type, .data$entity, .data$asset_class, .data$year,
       .data$tech_type, .data$ald_sector
     ) %>%
-    dplyr::summarise(perc_tech_exposure = sum(.data$plan_carsten, na.rm = TRUE)) %>%
+    dplyr::summarise(tech_plan_carsten = sum(.data$plan_carsten, na.rm = TRUE)) %>%
     dplyr::ungroup() %>%
     dplyr::group_by(
       .data$investor_name, .data$portfolio_name, .data$entity_name,
       .data$entity_type, .data$entity, .data$asset_class, .data$year,
       .data$ald_sector
     ) %>%
-    dplyr::mutate(perc_sec_exposure = sum(.data$perc_tech_exposure, na.rm = TRUE)) %>%
+    dplyr::mutate(sec_plan_carsten = sum(.data$tech_plan_carsten, na.rm = TRUE)) %>%
+    dplyr::mutate(perc_tech_exposure = .data$tech_plan_carsten/.data$sec_plan_carsten) %>%
     dplyr::ungroup() %>%
     dplyr::rename(sector = "ald_sector") %>%
     dplyr::arrange(


### PR DESCRIPTION
BEFORE, where exposures were divided by full size of portfolio (since using `plan_tech_carsten`):
![Screen Shot 2022-11-19 at 4 04 23 PM](https://user-images.githubusercontent.com/8741309/202858158-af874bfc-a546-45e7-8f5d-a7da69615d5d.png)

NOW, carsten values are renormalized to sector value (effectively only considering sector exposure):
![Screen Shot 2022-11-19 at 4 24 04 PM](https://user-images.githubusercontent.com/8741309/202858181-da76dcff-c1ca-43e5-b66b-19b592653988.png)
