### PR TITLE
sepearte exposure functions for separate plots

### DIFF
--- a/R/prep_green_brown_bars.R
+++ b/R/prep_green_brown_bars.R
@@ -99,15 +99,14 @@ calculate_exposures <- function(data) {
       .data$entity_type, .data$entity, .data$asset_class, .data$year,
       .data$tech_type, .data$ald_sector
     ) %>%
-    dplyr::summarise(tech_plan_carsten = sum(.data$plan_carsten, na.rm = TRUE)) %>%
+    dplyr::summarise(perc_tech_exposure = sum(.data$plan_carsten, na.rm = TRUE)) %>%
     dplyr::ungroup() %>%
     dplyr::group_by(
       .data$investor_name, .data$portfolio_name, .data$entity_name,
       .data$entity_type, .data$entity, .data$asset_class, .data$year,
       .data$ald_sector
     ) %>%
-    dplyr::mutate(sec_plan_carsten = sum(.data$tech_plan_carsten, na.rm = TRUE)) %>%
-    dplyr::mutate(perc_tech_exposure = .data$tech_plan_carsten/.data$sec_plan_carsten) %>%
+    dplyr::mutate(perc_sec_exposure = sum(.data$perc_tech_exposure, na.rm = TRUE)) %>%
     dplyr::ungroup() %>%
     dplyr::rename(sector = "ald_sector") %>%
     dplyr::arrange(


### PR DESCRIPTION
this #166 interfered with the green_brown exposure plot which now always threw errors. It still expected 

so I extracted the change of the above fix into a new function that is specifically used for the scatter plot and not for the green brown bars.
The one used for green brown bars is reverted, everything working again