### PR TITLE
use de language in real estate when language setting is EN

### DIFF
--- a/inst/extdata/PA2022CH_en_exec_summary/real-estate-chapter.Rmd
+++ b/inst/extdata/PA2022CH_en_exec_summary/real-estate-chapter.Rmd
@@ -8,6 +8,12 @@ Emissions from the Swiss building stock currently account for just over a quarte
 ```
 
 ```{r real_estate_load_data}
+# keep original setting so that it can be retrieved after fixing for missing paths in english
+language_original <- language
+if (language_original == "EN") {
+  language <- "DE"
+}
+
 real_estate_data <- jsonlite::read_json(
   path = file.path(real_estate_dir, "data", "data.json")
 )[["exec_sum"]]
@@ -39,6 +45,11 @@ cleaned_mortgage_paths <- mortgage_paths %>%
   remove_list_null %>%
   lapply(X = ., FUN = convert_re_user_path)
 stopifnot(all(sapply(X = cleaned_mortgage_paths, FUN = file.exists)))
+
+if (language_original == "EN") {
+  language <- "EN"
+}
+
 ```
 
 ```{=latex}


### PR DESCRIPTION
**expectation**
the executive summary part of the real estate `data.json` should have entries for en, de and fr for both direct real estate and mortgages. When an asset type is missing for a user, the values should be NULL for all three languages (but the keys should still exist)

**situation**
If a user has language == EN, there may be missing data paths in the RE `data.json` file, if the user has no data for mortgages
in all such cases, NULL values for DR and FR still exist

**suggested solution**
to avoid failure, we change language to DE temporarily in the RE section, since the DE and EN versions use the exact same graphs anyway


**more context on the situation**

well behaved missing data
<img width="564" alt="Screenshot 2022-11-21 at 08 25 42" src="https://user-images.githubusercontent.com/60064070/202990052-70f8fbd6-39e9-4693-bb4c-6f865cc465dd.png">

badly behaved missing data
<img width="656" alt="Screenshot 2022-11-21 at 08 25 24" src="https://user-images.githubusercontent.com/60064070/202989931-09e458b8-19d0-4154-a68c-6ee509212598.png">
