### PR TITLE
handle missing real estate data in score card

### DIFF
--- a/inst/extdata/PA2022CH_de_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2022CH_de_exec_summary/scorecard.Rmd
@@ -275,14 +275,14 @@ CO\textsubscript{2}-Intensität nach GEAK-Klassen (Portfoliodurchschnitt)
 
 \begin{itemize}
 \item Direkt gehaltene Gebäude:
-`r real_estate_data[["real_estate"]][["co2eq_emissions"]]`
+`r tryCatch({real_estate_data[["real_estate"]][["co2eq_emissions"]]}, error = function(e) {NULL})`
 \(\rightarrow\)
-`r real_estate_data[["real_estate"]][["co2eq_emissions_grade"]]`
+`r tryCatch({real_estate_data[["real_estate"]][["co2eq_emissions_grade"]]}, error = function(e) {NULL})`
 
 \item Hypotheken:
-`r real_estate_data[["mortgage"]][["co2eq_emissions"]]`
+`r tryCatch({real_estate_data[["mortgage"]][["co2eq_emissions"]]}, error = function(e) {NULL})`
 \(\rightarrow\)
-`r real_estate_data[["mortgage"]][["co2eq_emissions_grade"]]`
+`r tryCatch({real_estate_data[["mortgage"]][["co2eq_emissions_grade"]]}, error = function(e) {NULL})`
 
 \end{itemize}
 

--- a/inst/extdata/PA2022CH_en_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2022CH_en_exec_summary/scorecard.Rmd
@@ -274,14 +274,14 @@ CO\textsubscript{2} intensity according to GEAK classes (Means of the participan
 
 \begin{itemize}
 \item Directly held buildings:
-`r real_estate_data[["real_estate"]][["co2eq_emissions"]]`
+`r tryCatch({real_estate_data[["real_estate"]][["co2eq_emissions"]]}, error = function(e) {NULL})`
 \(\rightarrow\)
-`r real_estate_data[["real_estate"]][["co2eq_emissions_grade"]]`
+`r tryCatch({real_estate_data[["real_estate"]][["co2eq_emissions_grade"]]}, error = function(e) {NULL})`
 
 \item Mortgages:
-`r real_estate_data[["mortgage"]][["co2eq_emissions"]]`
+`r tryCatch({real_estate_data[["mortgage"]][["co2eq_emissions"]]}, error = function(e) {NULL})`
 \(\rightarrow\)
-`r real_estate_data[["mortgage"]][["co2eq_emissions_grade"]]`
+`r tryCatch({real_estate_data[["mortgage"]][["co2eq_emissions_grade"]]}, error = function(e) {NULL})`
 
 \end{itemize}
 

--- a/inst/extdata/PA2022CH_fr_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2022CH_fr_exec_summary/scorecard.Rmd
@@ -277,14 +277,14 @@ Intensité de CO\textsubscript{2} selon les classes GEAK (Moyens du participant)
 
 \begin{itemize}
 \item Bâtiments à tenue directe:
-`r real_estate_data[["real_estate"]][["co2eq_emissions"]]`
+`r tryCatch({real_estate_data[["real_estate"]][["co2eq_emissions"]]}, error = function(e) {NULL})`
 \(\rightarrow\)
-`r real_estate_data[["real_estate"]][["co2eq_emissions_grade"]]`
+`r tryCatch({real_estate_data[["real_estate"]][["co2eq_emissions_grade"]]}, error = function(e) {NULL})`
 
 \item Hypothèques:
-`r real_estate_data[["mortgage"]][["co2eq_emissions"]]`
+`r tryCatch({real_estate_data[["mortgage"]][["co2eq_emissions"]]}, error = function(e) {NULL})`
 \(\rightarrow\)
-`r real_estate_data[["mortgage"]][["co2eq_emissions_grade"]]`
+`r tryCatch({real_estate_data[["mortgage"]][["co2eq_emissions_grade"]]}, error = function(e) {NULL})`
 
 \end{itemize}
 


### PR DESCRIPTION
if real estate data cannot be found for a user, the blocks using the reaL_estate in text retrun NULL rather than erroring out