### PR TITLE
fix exposure plot in scorecard

### DIFF
--- a/R/prep_exposures_scorecard.R
+++ b/R/prep_exposures_scorecard.R
@@ -63,7 +63,7 @@ wrangle_data_exposures_scorecard <- function(data) {
     dplyr::mutate(
       sector_or_tech = dplyr::case_when(
         .data$ald_sector == "coal" ~ "coal",
-        .data$ald_sector == "oil and gas" ~ "other_fossil_fuels",
+        .data$ald_sector == "oil_and_gas" ~ "other_fossil_fuels",
         .data$technology %in% c("coalcap", "gascap", "oilcap") ~ "fossil_power",
         .data$technology == "renewablescap" ~ "renewables_power",
         TRUE ~ NA_character_

--- a/R/prep_exposures_scorecard.R
+++ b/R/prep_exposures_scorecard.R
@@ -63,6 +63,7 @@ wrangle_data_exposures_scorecard <- function(data) {
     dplyr::mutate(
       sector_or_tech = dplyr::case_when(
         .data$ald_sector == "coal" ~ "coal",
+        .data$ald_sector == "oil and gas" ~ "other_fossil_fuels",
         .data$ald_sector == "oil_and_gas" ~ "other_fossil_fuels",
         .data$technology %in% c("coalcap", "gascap", "oilcap") ~ "fossil_power",
         .data$technology == "renewablescap" ~ "renewables_power",

--- a/R/prep_exposures_survey.R
+++ b/R/prep_exposures_survey.R
@@ -11,7 +11,7 @@
 #'   aggregate peer group level PACTA results from a PACTA for investors
 #'   analysis.
 #' @param sector Character. Must be of length 1 and either `coal` or
-#'   `oil and gas`.
+#'   `oil_and_gas`.
 #' @param asset_class Character. Must be of length 1 and either `equity` or
 #'   `bonds`.
 #'


### PR DESCRIPTION
when changing the mapper a while back, we missed updating `"oil and gas"` to `"oil_and_gas"`. Now fixed, the sector is showing in the ES

<img width="519" alt="Screenshot 2022-11-22 at 19 16 25" src="https://user-images.githubusercontent.com/60064070/203391790-efdb21fc-9fb7-4cbb-b894-6ea8db774261.png">
