### PR TITLE
Align `preambles.tex` across EN, FR and DE

### DIFF
--- a/inst/extdata/PA2022CH_de_exec_summary/preamble.tex
+++ b/inst/extdata/PA2022CH_de_exec_summary/preamble.tex
@@ -3,6 +3,7 @@
 \usepackage{xcolor}
 \usepackage{mdframed}
 \usepackage{multicol}
+\usepackage{hyperref}
 
 % \usepackage[default]{opensans}
 \usepackage[T1]{fontenc}

--- a/inst/extdata/PA2022CH_fr_exec_summary/preamble.tex
+++ b/inst/extdata/PA2022CH_fr_exec_summary/preamble.tex
@@ -3,6 +3,7 @@
 \usepackage{xcolor}
 \usepackage{mdframed}
 \usepackage{multicol}
+\usepackage{hyperref}
 
 % \usepackage[default]{opensans}
 \usepackage[T1]{fontenc}


### PR DESCRIPTION
The files `preamble.tex` seem to have fallen out of sync. `hyperref` package was missing from DE and FR