### PR TITLE
fix wording and compiling issue

### DIFF
--- a/inst/extdata/PA2022CH_de_exec_summary/template.Rmd
+++ b/inst/extdata/PA2022CH_de_exec_summary/template.Rmd
@@ -656,7 +656,7 @@ Anteile der über bzw. unter dem Absenkpfad gemäss der "Langfristigen Klimastra
 
 \begin{esbox}{Welches sind die PACTA-Sektoren?}
 
-Die PACTA-Analyse deckt acht klimarelevante Sektoren ab: Kohle, Öl & Gas, Strom, Automobilindustrie, Zement, Stahl und Luftfahrt. In der Regel sind die Portfolios von Finanzinstituten wertemässig zu 5-15\% in diesen Sektoren investiert. Das finanzielle Engagement mag zwar gering erscheinen, aber im Durchschnitt sind die Anlagen für einen viel grösseren Anteil der Emissionen verantwortlich. Nachstehend sind die Grafiken eines Beispielportfolios dargestellt: 
+Die PACTA-Analyse deckt acht klimarelevante Sektoren ab: Kohle, Öl und Gas, Strom, Automobilindustrie, Zement, Stahl und Luftfahrt. In der Regel sind die Portfolios von Finanzinstituten wertemässig zu 5-15\% in diesen Sektoren investiert. Das finanzielle Engagement mag zwar gering erscheinen, aber im Durchschnitt sind die Anlagen für einen viel grösseren Anteil der Emissionen verantwortlich. Nachstehend sind die Grafiken eines Beispielportfolios dargestellt: 
 
 \begin{center}
 


### PR DESCRIPTION
the "&" character was not escaped and we don't use it in the German template, so I replaced it