### PR TITLE
Fix outstanding degree symbol rendering in scorecard .Rmd

### DIFF
--- a/inst/extdata/PA2022CH_de_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2022CH_de_exec_summary/scorecard.Rmd
@@ -569,9 +569,9 @@ _Für diesen Indikator wurden im Rahmen des PACTA-Klimatests 2022 keine Informat
 
 **Zwingende Anforderungen an die Datenanbieter:**
 
-* Lassen Sie sich vom 2050-Netto-Null-Ziel leiten, welches mit der 1,5°C-Erwärmungsgrenze des Klimaübereinkommen von Paris und den neuesten Erkenntnissen des Weltklimarats im Einklang steht.
+* Lassen Sie sich vom 2050-Netto-Null-Ziel leiten, welches mit der 1,5\u00B0C-Erwärmungsgrenze des Klimaübereinkommen von Paris und den neuesten Erkenntnissen des Weltklimarats im Einklang steht.
 * Befolgen Sie die technischen Überlegungen des TCFD 2021 PAT-Berichts „Measuring Portfolio Alignment - technical considerations“ („Messung der Klimaausrichtung des Portfolios – technische Überlegungen“). Halten Sie insbesondere folgende Punkte ein:
-  * Wählen Sie ein 1,5°C-Szenario, das mindestens den von der Science Based Targets Initiative (SBTi) in dem Dokument „Foundations of Science-Based Target Setting“ („Grundlagen der wissenschaftsbasierten Zielsetzung“) dargelegten Kriterien entspricht (Betrachtung 7).
+  * Wählen Sie ein 1,5\u00B0C-Szenario, das mindestens den von der Science Based Targets Initiative (SBTi) in dem Dokument „Foundations of Science-Based Target Setting“ („Grundlagen der wissenschaftsbasierten Zielsetzung“) dargelegten Kriterien entspricht (Betrachtung 7).
   * Priorisieren Sie granulare Benchmarks, wenn diese wesentliche Unterschiede in der Realisierbarkeit der Dekarbonisierung zwischen Branchen oder Regionen aufzeigen (Betrachtung 8).
   * Beziehen Sie Scope-3-Emissionen für die Sektoren ein, die am bedeutendsten sind und für die Benchmarks leicht aus bestehenden Szenarien entnommen werden können (fossile Brennstoffe, Bergbau, Automobilindustrie) (Betrachtung 11). 
   * Zusatz: Beachten Sie, dass PACTA nicht auf den Emissionen, sondern auf den Produktionsplänen der Unternehmen basiert. Die produktionsbasierte Analyse ermöglicht es, die folgenden Bereiche so genau wie möglich abzubilden: 
@@ -600,9 +600,9 @@ Langfristige Unternehmensziele, kurzfristige Massnahmen und Datenquellen:
 Zur Berechnung der Klimaausrichtung des Portfolios
 
 * _Zusatz:_ Der PACTA-Gesamtscore zur Klimaausrichtung ist keine Bewertung des impliziten Temperaturanstiegs (ITR). Aus diesem Grund kann PACTA für den Score selbst kein Konfidenzniveau angeben. Stattdessen gibt es folgende Konfidenz-Szenarien: 
-  * Wahrscheinlichkeit von 50%, dass im Szenario mit 1,5°C-Ziel und einheitlichem CO2-Preis (GECO 2021) die globale Erwärmung 1,5°C nicht überschreitet
-  * Wahrscheinlichkeit von 50%, dass im Szenario mit 1,8°C-Ziel und Umsetzung der nationalen Beiträge (NDC) sowie langfristigen Strategien der Vertragsstaaten (LTS) (GECO 2021) die globale Erwärmung 1,8°C nicht überschreitet
-  * Wahrscheinlichkeit von 50%, dass im Szenario mit 3,0°C-Ziel und Umsetzung der bisher beschlossenen politischen Massnahmen (GECO 2021) die globale Erwärmung 3,0°C nicht überschreitet
+  * Wahrscheinlichkeit von 50%, dass im Szenario mit 1,5\u00B0C-Ziel und einheitlichem CO2-Preis (GECO 2021) die globale Erwärmung 1,5\u00B0C nicht überschreitet
+  * Wahrscheinlichkeit von 50%, dass im Szenario mit 1,8\u00B0C-Ziel und Umsetzung der nationalen Beiträge (NDC) sowie langfristigen Strategien der Vertragsstaaten (LTS) (GECO 2021) die globale Erwärmung 1,8\u00B0C nicht überschreitet
+  * Wahrscheinlichkeit von 50%, dass im Szenario mit 3,0\u00B0C-Ziel und Umsetzung der bisher beschlossenen politischen Massnahmen (GECO 2021) die globale Erwärmung 3,0\u00B0C nicht überschreitet
 * _Anforderungen nicht erfüllt,_ da der Gesamtscore kein ITR-Score ist.
   * Die impliziten Temperaturwerte sollen mit einem Konfidenzniveau von 66\% statt 50\% berechnet werden. 
   * Die Erwärmungswerte werden auf Basis der kumulierten Emissionen bis 2050 berechnet, um die physikalische Beziehung zwischen kumulierten Emissionen und der Erwärmung angemessen zu berücksichtigen.

--- a/inst/extdata/PA2022CH_en_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2022CH_en_exec_summary/scorecard.Rmd
@@ -571,9 +571,9 @@ _The information for this indicator was not collected in the PACTA Climate Test 
 
 **Hard requirements:**
 
-* Be guided by the goal to achieve net zero emissions by 2050, consistent with the 1.5°C warming limit of the Paris Agreement and in line with the latest IPCC findings.
+* Be guided by the goal to achieve net zero emissions by 2050, consistent with the 1.5\u00B0C warming limit of the Paris Agreement and in line with the latest IPCC findings.
 * Comply with the technical considerations of the TCFD 2021 PAT report “Measuring Portfolio Alignment – technical considerations”. In particular, comply with:
-  * Select a 1.5°C scenario that complies, at a minimum, with the scenario selection criteria set out by the Science Based Targets initiative (SBTi) in their document Foundations of Science-Based Target Setting (consideration 7).
+  * Select a 1.5\u00B0C scenario that complies, at a minimum, with the scenario selection criteria set out by the Science Based Targets initiative (SBTi) in their document Foundations of Science-Based Target Setting (consideration 7).
   * Prioritize granular benchmarks where they meaningfully capture material differences in decarbonization feasibility across industries or regions (Consideration 8).
   * Include Scope 3 emissions for the sectors for which they are most material and for which benchmarks can be easily extracted from existing scenarios (fossil fuels, mining, automotive) (Consideration 11). 
   * _Addition:_ Note that the PACTA methodology is not based on emissions but on production plans of companies. The production-based analysis however proxies for the following scopes: 
@@ -602,9 +602,9 @@ Company long-term targets, near-term action and data sources:
 To calculate portfolio alignment
 
 * _Addition:_ The PACTA Aggregated Climate Alignment Score is not an Implied Temperature Rise (ITR) score. Therefore, PACTA cannot provide a confidence level for the score itself. Instead, confidence scenarios for the selected scenarios exist and are: 
-  * 50\% probability to not exceed 1.5°C warming for the 1.5°C Uniform scenario (GECO 2021)
-  * 50\% probability to not exceed 1.8°C warming for the 1.8°C NDC-LTS scenario (GECO 2021)
-  * 50\% probability to not exceed 3.0°C warming for the 3.0°C Current Policies Scenario (GECO 2021)
+  * 50\% probability to not exceed 1.5\u00B0C warming for the 1.5\u00B0C Uniform scenario (GECO 2021)
+  * 50\% probability to not exceed 1.8\u00B0C warming for the 1.8\u00B0C NDC-LTS scenario (GECO 2021)
+  * 50\% probability to not exceed 3.0\u00B0C warming for the 3.0\u00B0C Current Policies Scenario (GECO 2021)
 * _Requirements not met_ as Aggregate score is no ITR.
   * Implied temperature scores should be calculated using a confidence level of 66\%, rather than 50\%.
   * Calculate warming scores on a cumulative-emissions basis until 2050, in order to accommodate appropriately the physical relationship between cumulative emissions and warming outcomes.

--- a/inst/extdata/PA2022CH_fr_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2022CH_fr_exec_summary/scorecard.Rmd
@@ -571,9 +571,9 @@ _Les informations pour cet indicateur n'ont pas été collectées dans le test c
 
 **Exigences impératives:**
 
-* Laissez-vous guider par l'objectif de neutralité carbone d'ici 2050, conformément à la limite de réchauffement de 1,5°C de l'Accord de Paris et conformément aux dernières conclusions du GIEC.
+* Laissez-vous guider par l'objectif de neutralité carbone d'ici 2050, conformément à la limite de réchauffement de 1,5\u00B0C de l'Accord de Paris et conformément aux dernières conclusions du GIEC.
 * Se conformer aux considérations techniques du rapport PAT 2021 du TCFD intitulé \guillemetleft Evaluation de l'alignement du portefeuille – considérations techniques\guillemetright . Respecter notamment les points suivants:
-  * Sélectionner un scénario de 1,5°C qui respecte, au minimum, les critères de sélection de scénarios définis par l'initiative Science Based Targets (SBTi) dans son document intitulé \guillemetleft Foundations of Science-Based Target Setting\guillemetright \ (Fondements de l'établissement d'objectifs fondés sur la science) (considération 7).
+  * Sélectionner un scénario de 1,5\u00B0C qui respecte, au minimum, les critères de sélection de scénarios définis par l'initiative Science Based Targets (SBTi) dans son document intitulé \guillemetleft Foundations of Science-Based Target Setting\guillemetright \ (Fondements de l'établissement d'objectifs fondés sur la science) (considération 7).
   * Accorder la priorité aux indices de référence détaillés lorsqu'ils reflètent de manière significative des différences importantes dans la faisabilité de la décarbonation entre les industries ou les régions concernées (considération 8).
   * Inclure les émissions de catégorie 3 pour les secteurs pour lesquels elles sont les plus significatives et pour lesquels des indices de référence peuvent être facilement extraits des scénarios existants (combustibles fossiles, mines, automobile) (considération 11). 
   * En outre: A noter que la méthodologie PACTA ne se base pas sur les émissions mais sur les plans de production des entreprises. L'analyse basée sur la production donne cependant une indication des catégories suivantes: 
@@ -604,9 +604,9 @@ Objectifs à long terme de l'entreprise, actions à court terme et sources de do
 Pour calculer l'alignement du portefeuille
 
 * _En outre:_ Le score d'alignement climatique agrégé PACTA n'est pas un score d'augmentation implicite de la température (AIT). Par conséquent, la méthode PACTA ne peut pas fournir un niveau de confiance pour le score lui-même. Au lieu de cela, des scénarios fiables pour les scénarios sélectionnés existent et sont comme suit: 
-  * 50% de probabilité de ne pas dépasser 1,5°C de réchauffement pour le scénario uniforme de 1,5°C (GECO 2021)
-  * 50% de probabilité de ne pas dépasser 1,8°C de réchauffement pour le scénario de 1,8°C CDN-SLT (GECO 2021)
-  * Probabilité de 50% de ne pas dépasser 3,0°C de réchauffement pour le scénario des politiques actuelles de 3,0°C (GECO 2021) 
+  * 50% de probabilité de ne pas dépasser 1,5\u00B0C de réchauffement pour le scénario uniforme de 1,5\u00B0C (GECO 2021)
+  * 50% de probabilité de ne pas dépasser 1,8\u00B0C de réchauffement pour le scénario de 1,8\u00B0C CDN-SLT (GECO 2021)
+  * Probabilité de 50% de ne pas dépasser 3,0\u00B0C de réchauffement pour le scénario des politiques actuelles de 3,0\u00B0C (GECO 2021) 
 * _Exigences non satisfaites_ car le score global n'est pas un AIT.
   * Les scores de température implicites doivent être calculés en utilisant un niveau de confiance de 66\%, plutôt que de 50\%.
   * Calculer les scores de réchauffement sur une base d'émissions cumulées jusqu'en 2050 afin de tenir compte de manière appropriée de la relation physique entre les émissions cumulées et les résultats en termes de réchauffement.


### PR DESCRIPTION
My initial PR only handled the mis-rendering in LaTex, because I thought the .Rmd was rendering fine. 

It is now fixed in both: 

<img width="685" alt="Screen Shot 2022-11-23 at 1 31 44 PM" src="https://user-images.githubusercontent.com/8741309/203547682-170b473b-e046-44e1-a61e-b20c29aecbab.png">


Closes #200