### PR TITLE
add a {pkgdown} site

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,6 @@
 ^template.*$
 ^README\.Rmd$
 ^\.github$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,46 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.pdf
 *.html
 *template.log
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,4 +39,7 @@ Imports:
 Suggests: 
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
+Config/Needs/website: rmi-pacta/pacta.pkgdown.template
 Remotes: RMI-PACTA/r2dii.colours
+URL: https://rmi-pacta.github.io/pacta.executive.summary,
+     https://github.com/RMI-PACTA/pacta.executive.summary

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,5 @@
+url: https://rmi-pacta.github.io/pacta.executive.summary
+template:
+  package: pacta.pkgdown.template
+  bootstrap: 5
+

--- a/man/pacta.executive.summary-package.Rd
+++ b/man/pacta.executive.summary-package.Rd
@@ -10,6 +10,14 @@
 
 This package contains plotting functions and a template for generating the executive summary that displays aggregated results of a PACTA COP exercise.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://rmi-pacta.github.io/pacta.executive.summary}
+  \item \url{https://github.com/RMI-PACTA/pacta.executive.summary}
+}
+
+}
 \author{
 \strong{Maintainer}: Monika Furdyna \email{monika.furdyna@gmail.com} (\href{https://orcid.org/0000-0002-3728-0646}{ORCID}) [contractor]
 


### PR DESCRIPTION
Since this repo is public, and it's a legit R package, might as well have a {pkgdown} site.