### PR TITLE
remove {gridExtra} dependency, which is no longer needed after #175

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,6 @@ Imports:
     ggplot2,
     glue,
     grid,
-    gridExtra,
     magrittr,
     patchwork,
     png,


### PR DESCRIPTION
remove {gridExtra} dependency, which is no longer needed after #175