### PR TITLE
use proper argument name `emissions_data`

### DIFF
--- a/R/prep_scores_scorecard.R
+++ b/R/prep_scores_scorecard.R
@@ -57,7 +57,7 @@ prep_scores_scorecard <- function(results_portfolio,
 #' @export
 prep_scores_emissions_scorecard <- function(emissions_data,
                                             log_dir = .GlobalEnv$log_dir) {
-  if (is.null(emissions)) {
+  if (is.null(emissions_data)) {
     data_out <- NULL
     return(data_out)
   } else {
@@ -117,7 +117,7 @@ prep_scores_exposure_scorecard <- function(audit_data,
                                            currency_exchange_value,
                                            total_portfolio_value_curr,
                                            log_dir = .GlobalEnv$log_dir) {
-  if (is.null(emissions) || is.null(currency_exchange_value) || is.null(total_portfolio_value_curr)) {
+  if (is.null(emissions_data) || is.null(currency_exchange_value) || is.null(total_portfolio_value_curr)) {
     data_out <- NULL
     return(data_out)
   } else {


### PR DESCRIPTION
@MonikaFu I believe what's intended here is to test if the passed argument `emissions_data` is `NULL`?

But in `prep_scores_exposure_scorecard()` neither `emissions_data` nor `emissions` are arguments, so I'm not really sure what was intended there. Maybe the `is.null(emissions) || ` should be removed completely?