### PR TITLE
add dependabot to keep GH Actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+ updates:
+   - package-ecosystem: "github-actions"
+     directory: "/"
+     schedule:
+       interval: "weekly"


### PR DESCRIPTION
It will check weekly the GH Actions that are used and submit a PR automatically if there's an update.