### PR TITLE
fix column type

### DIFF
--- a/inst/extdata/PA2022CH_de_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2022CH_de_exec_summary/scorecard.Rmd
@@ -298,7 +298,7 @@ if (file.exists(file.path(score_card_dir, "climate_scorecard_survey_initiatives.
       user_id = "n",
       peer_group = "c",
       name_climate_initiative = "c",
-      climate_initiative = "n"
+      climate_initiative = "l"
     )
   )
 } else {
@@ -306,7 +306,7 @@ if (file.exists(file.path(score_card_dir, "climate_scorecard_survey_initiatives.
     user_id = 0,
     peer_group = peer_group,
     name_climate_initiative = NA_character_,
-    climate_initiative = NA_real_
+    climate_initiative = NA
   )
 }
 

--- a/inst/extdata/PA2022CH_en_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2022CH_en_exec_summary/scorecard.Rmd
@@ -297,7 +297,7 @@ if (file.exists(file.path(score_card_dir, "climate_scorecard_survey_initiatives.
       user_id = "n",
       peer_group = "c",
       name_climate_initiative = "c",
-      climate_initiative = "n"
+      climate_initiative = "l"
     )
   )
 } else {
@@ -305,7 +305,7 @@ if (file.exists(file.path(score_card_dir, "climate_scorecard_survey_initiatives.
     user_id = 0,
     peer_group = peer_group,
     name_climate_initiative = NA_character_,
-    climate_initiative = NA_real_
+    climate_initiative = NA
   )
 }
 

--- a/inst/extdata/PA2022CH_fr_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2022CH_fr_exec_summary/scorecard.Rmd
@@ -300,7 +300,7 @@ if (file.exists(file.path(score_card_dir, "climate_scorecard_survey_initiatives.
       user_id = "n",
       peer_group = "c",
       name_climate_initiative = "c",
-      climate_initiative = "n"
+      climate_initiative = "l"
     )
   )
 } else {
@@ -308,7 +308,7 @@ if (file.exists(file.path(score_card_dir, "climate_scorecard_survey_initiatives.
     user_id = 0,
     peer_group = peer_group,
     name_climate_initiative = NA_character_,
-    climate_initiative = NA_real_
+    climate_initiative = NA
   )
 }
 


### PR DESCRIPTION
closes ADO 5887: https://dev.azure.com/RMI-PACTA/2DegreesInvesting/_workitems/edit/5887?src=WorkItemMention&src-action=artifact_link

This PR:
- fixes the column type of the climate initiative indicator when reading in pre-generated user results
- it was falsely set to numeric and should be logical
- the numeric type lead to TRUE values turning into NAs, which means that members of initiatives will falsely see  a "NO" value, for their overall survey replies to the relevant question in the climate score card