### PR TITLE
feat: executive summary gains `scenario` and `scenario_source` specificity 

### DIFF
--- a/R/render_executive_summary.R
+++ b/R/render_executive_summary.R
@@ -11,7 +11,8 @@
 #' @param portfolio_name Character single string specifying the portfolio name
 #' @param peer_group Character single string specifying the peer group
 #' @param total_portfolio Data frame that contains the total portfolio as found in the standard PACTA processed inputs file "total_portfolio.rds"
-#' @param scenario_selected Character single string specifying the selected scenario, e.g. "1.5C-Unif"
+#' @param scenario_source_selected Character single string specifying the selected scenario source, e.g. "GECO2023"
+#' @param scenario_selected Character single string specifying the selected scenario, e.g. "1.5C"
 #' @param currency_exchange_value Numeric single numeric value specifying the exchange rate from USD into the desired display currency, e.g. `1.03`
 #' @param log_dir Character single, valid filepath to a directory that will contain the log file
 #'
@@ -29,6 +30,7 @@ render_executive_summary <- function(data,
                                      portfolio_name,
                                      peer_group,
                                      total_portfolio,
+                                     scenario_source_selected,
                                      scenario_selected,
                                      currency_exchange_value,
                                      log_dir) {
@@ -44,6 +46,7 @@ render_executive_summary <- function(data,
       investor_name = investor_name,
       portfolio_name = portfolio_name,
       peer_group = peer_group,
+      scenario_source_selected = scenario_source_selected,
       scenario_selected = scenario_selected,
       audit_data = data$audit_data,
       emissions_data = data$emissions_data,

--- a/R/render_executive_summary.R
+++ b/R/render_executive_summary.R
@@ -30,8 +30,8 @@ render_executive_summary <- function(data,
                                      portfolio_name,
                                      peer_group,
                                      total_portfolio,
-                                     scenario_source_selected,
-                                     scenario_selected,
+                                     scenario_source_selected = "GECO2021",
+                                     scenario_selected = "1.5C-Unif",
                                      currency_exchange_value,
                                      log_dir) {
   render(

--- a/inst/extdata/PA2022CH_de_exec_summary/template.Rmd
+++ b/inst/extdata/PA2022CH_de_exec_summary/template.Rmd
@@ -17,6 +17,7 @@ params:
   peer_group: pensionfund
   audit_data: NULL
   total_portfolio: NULL
+  scenario_source_selected: NULL
   scenario_selected: NULL
   emissions_data: NULL
   results_portfolio: NULL

--- a/inst/extdata/PA2022CH_en_exec_summary/template.Rmd
+++ b/inst/extdata/PA2022CH_en_exec_summary/template.Rmd
@@ -17,6 +17,7 @@ params:
   peer_group: pensionfund
   audit_data: NULL
   total_portfolio: NULL
+  scenario_source_selected: NULL
   scenario_selected: NULL
   emissions_data: NULL
   results_portfolio: NULL

--- a/inst/extdata/PA2022CH_fr_exec_summary/template.Rmd
+++ b/inst/extdata/PA2022CH_fr_exec_summary/template.Rmd
@@ -17,6 +17,7 @@ params:
   peer_group: pensionfund
   audit_data: NULL
   total_portfolio: NULL
+  scenario_source_selected: NULL
   scenario_selected: NULL
   emissions_data: NULL
   results_portfolio: NULL

--- a/inst/extdata/PA2022FL_en_exec_summary/template.Rmd
+++ b/inst/extdata/PA2022FL_en_exec_summary/template.Rmd
@@ -17,6 +17,7 @@ params:
   peer_group: pensionfund
   audit_data: NULL
   total_portfolio: NULL
+  scenario_source_selected: NULL
   scenario_selected: NULL
   emissions_data: NULL
   results_portfolio: NULL

--- a/inst/extdata/PA2024CH_de_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2024CH_de_exec_summary/scorecard.Rmd
@@ -100,7 +100,10 @@ Es besteht ein wissenschaftlicher Konsens über die Notwendigkeit, aus Kohle aus
 
 tryCatch(
   {
-    data_exposures_scorecard <- prep_exposures_scorecard(results_portfolio)
+    data_exposures_scorecard <- prep_exposures_scorecard(
+      results_portfolio,
+      scenario_selected = scenario_selected
+      )
     plot_exposures_scorecard(data_exposures_scorecard)
   },
   error = function(e) {
@@ -126,7 +129,10 @@ tryCatch(
 ```{r scores_scorecard, fig.height=3}
 tryCatch(
   {
-    data_scores_scorecard <- prep_scores_scorecard(results_portfolio)
+    data_scores_scorecard <- prep_scores_scorecard(
+      results_portfolio,
+      scenario_source = scenario_source_selected
+      )
     plot_scores_scorecard(data_scores_scorecard)
   },
   error = function(e) {

--- a/inst/extdata/PA2024CH_de_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_de_exec_summary/template.Rmd
@@ -15,6 +15,7 @@ params:
   peer_group: pensionfund
   audit_data: NULL
   total_portfolio: NULL
+  scenario_source_selected: NULL
   scenario_selected: NULL
   emissions_data: NULL
   results_portfolio: NULL
@@ -259,6 +260,7 @@ tryCatch(
       peers_results_individual = peers_results_individual,
       indices_results_portfolio = indices_results_portfolio,
       scenario_selected = scenario_selected,
+      scenario_source = scenario_source_selected,
       asset_class = "bonds"
     )
 
@@ -289,6 +291,7 @@ tryCatch(
       peers_results_individual = peers_results_individual,
       indices_results_portfolio = indices_results_portfolio,
       scenario_selected = scenario_selected,
+      scenario_source = scenario_source_selected,
       asset_class = "equity"
     )
 
@@ -329,7 +332,8 @@ tryCatch(
     data_scores_b <- prep_scores(
       results_portfolio = results_portfolio,
       peers_results_aggregated = peers_results_aggregated,
-      asset_class = "bonds"
+      asset_class = "bonds",
+      scenario_source = scenario_source_selected
     )
     plot_scores(data_scores_b) +
       patchwork::plot_annotation(
@@ -351,7 +355,8 @@ tryCatch(
     data_scores_e <- prep_scores(
       results_portfolio = results_portfolio,
       peers_results_aggregated = peers_results_aggregated,
-      asset_class = "equity"
+      asset_class = "equity",
+      scenario_source = scenario_source_selected
     )
     plot_scores(data_scores_e) +
       patchwork::plot_annotation(
@@ -394,7 +399,8 @@ tryCatch(
     data_alignment_table <- prep_alignment_table(
       results_portfolio = results_portfolio, 
       peers_results_aggregated = peers_results_aggregated,
-      asset_class = "bonds"
+      asset_class = "bonds",
+      scenario_source = scenario_source_selected
     )
     plot_alignment_table(data_alignment_table) +
     patchwork::plot_annotation(
@@ -419,7 +425,8 @@ tryCatch(
     data_alignment_table <- prep_alignment_table(
       results_portfolio = results_portfolio, 
       peers_results_aggregated = peers_results_aggregated,
-      asset_class = "equity"
+      asset_class = "equity",
+      scenario_source = scenario_source_selected
     )
     plot_alignment_table(data_alignment_table) +
     patchwork::plot_annotation(

--- a/inst/extdata/PA2024CH_en_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2024CH_en_exec_summary/scorecard.Rmd
@@ -101,7 +101,10 @@ There is scientific consensus on the need to phase-out coal, stop financing new 
 
 tryCatch(
   {
-    data_exposures_scorecard <- prep_exposures_scorecard(results_portfolio)
+    data_exposures_scorecard <- prep_exposures_scorecard(
+      results_portfolio,
+      scenario_selected = scenario_selected
+    )
     plot_exposures_scorecard(data_exposures_scorecard)
   },
   error = function(e) {

--- a/inst/extdata/PA2024CH_en_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_en_exec_summary/template.Rmd
@@ -15,6 +15,7 @@ params:
   peer_group: pensionfund
   audit_data: NULL
   total_portfolio: NULL
+  scenario_source_selected: NULL
   scenario_selected: NULL
   emissions_data: NULL
   results_portfolio: NULL
@@ -266,6 +267,7 @@ tryCatch(
       peers_results_individual = peers_results_individual,
       indices_results_portfolio = indices_results_portfolio,
       scenario_selected = scenario_selected,
+      scenario_source = scenario_source_selected,
       asset_class = "bonds"
     )
 
@@ -296,6 +298,7 @@ tryCatch(
       peers_results_individual = peers_results_individual,
       indices_results_portfolio = indices_results_portfolio,
       scenario_selected = scenario_selected,
+      scenario_source = scenario_source_selected,
       asset_class = "equity"
     )
 
@@ -336,7 +339,8 @@ tryCatch(
     data_scores_b <- prep_scores(
       results_portfolio = results_portfolio,
       peers_results_aggregated = peers_results_aggregated,
-      asset_class = "bonds"
+      asset_class = "bonds",
+      scenario_source = scenario_source_selected
     )
     plot_scores(data_scores_b) +
       patchwork::plot_annotation(
@@ -358,7 +362,8 @@ tryCatch(
     data_scores_e <- prep_scores(
       results_portfolio = results_portfolio,
       peers_results_aggregated = peers_results_aggregated,
-      asset_class = "equity"
+      asset_class = "equity",
+      scenario_source = scenario_source_selected
     )
     plot_scores(data_scores_e) +
       patchwork::plot_annotation(
@@ -398,7 +403,8 @@ tryCatch(
     data_alignment_table <- prep_alignment_table(
       results_portfolio = results_portfolio, 
       peers_results_aggregated = peers_results_aggregated,
-      asset_class = "bonds"
+      asset_class = "bonds",
+      scenario_source = scenario_source_selected
     )
     plot_alignment_table(data_alignment_table) +
     patchwork::plot_annotation(
@@ -423,7 +429,8 @@ tryCatch(
     data_alignment_table <- prep_alignment_table(
       results_portfolio = results_portfolio, 
       peers_results_aggregated = peers_results_aggregated,
-      asset_class = "equity"
+      asset_class = "equity",
+      scenario_source = scenario_source_selected
     )
     plot_alignment_table(data_alignment_table) +
     patchwork::plot_annotation(

--- a/inst/extdata/PA2024CH_fr_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2024CH_fr_exec_summary/scorecard.Rmd
@@ -100,7 +100,10 @@ Les milieux scientifiques s’accordent sur la nécessité de sortir du charbon,
 
 tryCatch(
   {
-    data_exposures_scorecard <- prep_exposures_scorecard(results_portfolio)
+    data_exposures_scorecard <- prep_exposures_scorecard(
+      results_portfolio,
+      scenario_selected = scenario_selected
+    )
     plot_exposures_scorecard(data_exposures_scorecard)
   },
   error = function(e) {

--- a/inst/extdata/PA2024CH_fr_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_fr_exec_summary/template.Rmd
@@ -15,6 +15,7 @@ params:
   peer_group: pensionfund
   audit_data: NULL
   total_portfolio: NULL
+  scenario_source_selected: NULL
   scenario_selected: NULL
   emissions_data: NULL
   results_portfolio: NULL
@@ -258,6 +259,7 @@ tryCatch(
       peers_results_individual = peers_results_individual,
       indices_results_portfolio = indices_results_portfolio,
       scenario_selected = scenario_selected,
+      scenario_source = scenario_source_selected,
       asset_class = "bonds"
     )
 
@@ -288,6 +290,7 @@ tryCatch(
       peers_results_individual = peers_results_individual,
       indices_results_portfolio = indices_results_portfolio,
       scenario_selected = scenario_selected,
+      scenario_source = scenario_source_selected,
       asset_class = "equity"
     )
 
@@ -328,7 +331,8 @@ tryCatch(
     data_scores_b <- prep_scores(
       results_portfolio = results_portfolio,
       peers_results_aggregated = peers_results_aggregated,
-      asset_class = "bonds"
+      asset_class = "bonds",
+      scenario_source = scenario_source_selected
     )
     plot_scores(data_scores_b) +
       patchwork::plot_annotation(
@@ -350,7 +354,8 @@ tryCatch(
     data_scores_e <- prep_scores(
       results_portfolio = results_portfolio,
       peers_results_aggregated = peers_results_aggregated,
-      asset_class = "equity"
+      asset_class = "equity",
+      scenario_source = scenario_source_selected
     )
     plot_scores(data_scores_e) +
       patchwork::plot_annotation(
@@ -391,7 +396,8 @@ tryCatch(
     data_alignment_table <- prep_alignment_table(
       results_portfolio = results_portfolio, 
       peers_results_aggregated = peers_results_aggregated,
-      asset_class = "bonds"
+      asset_class = "bonds",
+      scenario_source = scenario_source_selected
     )
     plot_alignment_table(data_alignment_table) +
     patchwork::plot_annotation(
@@ -416,7 +422,8 @@ tryCatch(
     data_alignment_table <- prep_alignment_table(
       results_portfolio = results_portfolio, 
       peers_results_aggregated = peers_results_aggregated,
-      asset_class = "equity"
+      asset_class = "equity",
+      scenario_source = scenario_source_selected
     )
     plot_alignment_table(data_alignment_table) +
     patchwork::plot_annotation(

--- a/man/render_executive_summary.Rd
+++ b/man/render_executive_summary.Rd
@@ -16,6 +16,7 @@ render_executive_summary(
   portfolio_name,
   peer_group,
   total_portfolio,
+  scenario_source_selected,
   scenario_selected,
   currency_exchange_value,
   log_dir
@@ -44,7 +45,9 @@ render_executive_summary(
 
 \item{total_portfolio}{Data frame that contains the total portfolio as found in the standard PACTA processed inputs file "total_portfolio.rds"}
 
-\item{scenario_selected}{Character single string specifying the selected scenario, e.g. "1.5C-Unif"}
+\item{scenario_source_selected}{Character single string specifying the selected scenario source, e.g. "GECO2023"}
+
+\item{scenario_selected}{Character single string specifying the selected scenario, e.g. "1.5C"}
 
 \item{currency_exchange_value}{Numeric single numeric value specifying the exchange rate from USD into the desired display currency, e.g. \code{1.03}}
 


### PR DESCRIPTION
It turns out that, while many of the `prep_` functions do utilize a parameterized `scenario` argument, we had just been relying on the default `1.5C-Unif` in most cases, for most functions. 

This PR does a few things, all broadly related to parameterizing the `scenario` and `scenario_source` selection:

- `render_executive_summary` gains argument `scenario_source_selected`
- all functions in all `2024` templates gain specification for `scenario_selected` and `scenario_source_selected` (as applicable)
- defaults to the 2022 values (`GECO2021` and `1.5C-Unif`) for backward compatibility. (I don't know how necessary that really is, but hey ho, why not follow good practices)
