### PR TITLE
feat: immediately filter for relevant `scenario_source`

### DIFF
--- a/R/prep_alignment_table.R
+++ b/R/prep_alignment_table.R
@@ -38,10 +38,10 @@ prep_alignment_table <- function(results_portfolio,
       dplyr::bind_rows(peers_results_aggregated)
 
     # get scenarios
-    scenario_thresholds <- get("scenario_thresholds")
+    scenario_thresholds <- get("scenario_thresholds") %>%
+      dplyr::filter(.data$scenario_source == .env$scenario_source)
 
     scenarios <- scenario_thresholds %>%
-      dplyr::filter(.data$scenario_source == .env$scenario_source) %>%
       dplyr::pull("scenario")
 
     # get scenarios for relevant thresholds


### PR DESCRIPTION
Since the `scenario_thresholds` file now has multiple possible `scenario_source`'s, it is important to quickly filter it for only the relevant source, otherwise strange bugs appear:

<img width="761" alt="Screenshot 2024-05-09 at 06 41 53" src="https://github.com/RMI-PACTA/pacta.executive.summary/assets/8741309/3e32d37c-d96c-47a0-8245-dc0a149229f6">
