### PR TITLE
fix: `prep_scorecard` template gains missing parameters

### DIFF
--- a/inst/extdata/PA2024CH_en_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2024CH_en_exec_summary/scorecard.Rmd
@@ -130,7 +130,10 @@ tryCatch(
 ```{r scores_scorecard, fig.height=3}
 tryCatch(
   {
-    data_scores_scorecard <- prep_scores_scorecard(results_portfolio)
+    data_scores_scorecard <- prep_scores_scorecard(
+      results_portfolio,
+      scenario_source = scenario_source
+    )
     plot_scores_scorecard(data_scores_scorecard)
   },
   error = function(e) {

--- a/inst/extdata/PA2024CH_fr_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2024CH_fr_exec_summary/scorecard.Rmd
@@ -130,7 +130,10 @@ tryCatch(
 ```{r scores_scorecard, fig.height=3}
 tryCatch(
   {
-    data_scores_scorecard <- prep_scores_scorecard(results_portfolio)
+    data_scores_scorecard <- prep_scores_scorecard(
+      results_portfolio,
+      scenario_source = scenario_source
+    )
     plot_scores_scorecard(data_scores_scorecard)
   },
   error = function(e) {


### PR DESCRIPTION
I somehow missed adding the parameters to these two functions in #314 