### PR TITLE
Use plots with peer info for engagement

### DIFF
--- a/inst/extdata/PA2024CH_de_exec_summary/survey-chapter.Rmd
+++ b/inst/extdata/PA2024CH_de_exec_summary/survey-chapter.Rmd
@@ -53,7 +53,7 @@ Untersuchungen zeigen, dass Engagement eine der effektivsten Methoden zur Verbes
 
 ```{r plot_layer_with_peer_info_engagement_left, out.width="\\linewidth"}
 knitr::include_graphics(
-file.path(survey_dir, language, "plot_layer_engagement.png")
+file.path(survey_dir, language, "plot_layer_peers_engagement.png")
 )
 ```
 
@@ -65,7 +65,7 @@ file.path(survey_dir, language, "plot_layer_engagement.png")
 
 ```{r plot_layer_with_peer_info_engagement_center, out.width="\\linewidth"}
 knitr::include_graphics(
-file.path(survey_dir, language, "plot_layer_voting.png")
+file.path(survey_dir, language, "plot_layer_peers_voting.png")
 )
 ```
 

--- a/inst/extdata/PA2024CH_en_exec_summary/survey-chapter.Rmd
+++ b/inst/extdata/PA2024CH_en_exec_summary/survey-chapter.Rmd
@@ -49,7 +49,7 @@ Research shows that engagement is one of the most effective ways to improve clim
 
 ```{r plot_layer_with_peer_info_engagement_left, out.width="\\linewidth"}
 knitr::include_graphics(
-file.path(survey_dir, language, "plot_layer_engagement.png")
+file.path(survey_dir, language, "plot_layer_peers_engagement.png")
 )
 ```
 
@@ -61,7 +61,7 @@ file.path(survey_dir, language, "plot_layer_engagement.png")
 
 ```{r plot_layer_with_peer_info_engagement_center, out.width="\\linewidth"}
 knitr::include_graphics(
-file.path(survey_dir, language, "plot_layer_voting.png")
+file.path(survey_dir, language, "plot_layer_peers_voting.png")
 )
 ```
 

--- a/inst/extdata/PA2024CH_fr_exec_summary/survey-chapter.Rmd
+++ b/inst/extdata/PA2024CH_fr_exec_summary/survey-chapter.Rmd
@@ -53,7 +53,7 @@ Les recherches indiquent que l'engagement constitue l'un des moyens les plus eff
 
 ```{r plot_layer_with_peer_info_engagement_left, out.width="\\linewidth"}
 knitr::include_graphics(
-file.path(survey_dir, language, "plot_layer_engagement.png")
+file.path(survey_dir, language, "plot_layer_peers_engagement.png")
 )
 ```
 
@@ -64,7 +64,7 @@ file.path(survey_dir, language, "plot_layer_engagement.png")
 
 ```{r plot_layer_with_peer_info_engagement_center, out.width="\\linewidth"}
 knitr::include_graphics(
-file.path(survey_dir, language, "plot_layer_voting.png")
+file.path(survey_dir, language, "plot_layer_peers_voting.png")
 )
 ```
 


### PR DESCRIPTION
In this PR I change the names of some plots to use the survey engagement plots with peer info as requested by FOEN. These changes will work if we are using the newest version of `user_data` as in this branch: https://github.com/RMI-PACTA/user_results/pull/24#issuecomment-2168243501

@AlexAxthelm can you help me set up testing to make sure this change works as intended?