### PR TITLE
Update scorecard to use new SBTi calculations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Description: This package contains plotting functions and a
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Depends: 
     R (>= 2.10)
 LazyData: true

--- a/R/render_executive_summary.R
+++ b/R/render_executive_summary.R
@@ -6,6 +6,7 @@
 #' @param exec_summary_dir Character single, valid filepath to a directory that contains the template, e.g. `system.file("extdata", "PA2022CH_en_exec_summary", package = "pacta.executive.summary")`
 #' @param survey_dir Character single, valid filepath to a directory that contains the survey files for the user
 #' @param score_card_dir Character single, valid filepath to a directory that contains score card files for the user
+#' @param analysis_inputs_dir: Character single, valid filepath to a PACTA analysis results directory that contains the SBTi data merged with financial data in the COP case
 #' @param file_name Character single, valid filename of the Rmd template file, e.g. "template.Rmd"
 #' @param investor_name Character single string specifying the investor name
 #' @param portfolio_name Character single string specifying the portfolio name
@@ -25,6 +26,7 @@ render_executive_summary <- function(data,
                                      exec_summary_dir,
                                      survey_dir,
                                      score_card_dir,
+                                     analysis_inputs_dir,
                                      file_name = "template.Rmd",
                                      investor_name,
                                      portfolio_name,
@@ -42,6 +44,7 @@ render_executive_summary <- function(data,
     params = list(
       survey_dir = survey_dir,
       score_card_dir = score_card_dir,
+      analysis_inputs_dir = analysis_inputs_dir,
       language = language,
       investor_name = investor_name,
       portfolio_name = portfolio_name,

--- a/R/render_executive_summary.R
+++ b/R/render_executive_summary.R
@@ -6,7 +6,7 @@
 #' @param exec_summary_dir Character single, valid filepath to a directory that contains the template, e.g. `system.file("extdata", "PA2022CH_en_exec_summary", package = "pacta.executive.summary")`
 #' @param survey_dir Character single, valid filepath to a directory that contains the survey files for the user
 #' @param score_card_dir Character single, valid filepath to a directory that contains score card files for the user
-#' @param analysis_inputs_dir: Character single, valid filepath to a PACTA analysis results directory that contains the SBTi data merged with financial data in the COP case
+#' @param analysis_inputs_dir Character single, valid filepath to a PACTA analysis results directory that contains the SBTi data merged with financial data in the COP case
 #' @param file_name Character single, valid filename of the Rmd template file, e.g. "template.Rmd"
 #' @param investor_name Character single string specifying the investor name
 #' @param portfolio_name Character single string specifying the portfolio name

--- a/inst/extdata/PA2024CH_de_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2024CH_de_exec_summary/scorecard.Rmd
@@ -185,44 +185,59 @@ Dieser Score zeigt die geschätzte Gesamtausrichtung der PACTA-Sektoren (ohne Ze
 
 \subsection{Verifizierte Bekenntnisse zu Netto-Null}
 
-Immer mehr Unternehmen bekennen sich freiwillig zu Netto-Null Emissionszielen und formulieren Zwischenziele. Die Wirksamkeit solcher Bekenntnisse hängt davon ab, ob die Zwischenziele glaubwürdig, wissenschaftlich fundiert und transparent sind. Die folgenden Informationen beruhen auf Angaben der SBTi \textbf{\href{https://sciencebasedtargets.org/companies-taking-action}{(link)}}.
+Companies are increasingly committing voluntarily to transitioning to net zero and setting interim targets. The effectiveness of such commitments depends on whether interim emissions reduction targets applied are credible, science-based, transparent, and supported by credible action to cut emissions. The following information is based on information from SBTi \textbf{\href{https://sciencebasedtargets.org/companies-taking-action}{(link)}}.
 
 ```
 
 ```{r sbti_net_zero_commitments}
 fin_data_net_zero_targets <- readr::read_csv(
-  file.path(score_card_dir, "fin_data_net_zero_targets.csv"),
+  file.path(analysis_inputs_dir, "fin_data_net_zero_targets.csv"),
   col_types = readr::cols_only(
     isin = "c",
     asset_type = "c",
-    factset_entity_id = "c"
+    factset_entity_id = "c",
+    has_net_zero_commitment = "l"
   )
 )
 
-peer_group_share_net_zero <- readr::read_csv(
-  file.path(score_card_dir, "peer_group_share_net_zero.csv"),
+peers_net_zero_commitment <- readr::read_csv(
+  file.path(score_card_dir, "peers_sbti_results.csv"),
   col_types = readr::cols_only(
     investor_name = "c",
     portfolio_name = "c",
-    share_net_zero = "n"
+    company_share_net_zero = "d",
+    exposure_share_net_zero = "d"
   )
 )
 
-data_prep_net_zero_commitments <- prep_net_zero_commitments(
+data_net_zero_commitments <- prep_net_zero_commitments(
   total_portfolio = total_portfolio,
   peer_group = peer_group,
-  net_zero_targets = fin_data_net_zero_targets,
-  peer_group_share_net_zero = peer_group_share_net_zero
+  fin_data_net_zero_targets = fin_data_net_zero_targets,
+  peers_net_zero_commitment = peers_net_zero_commitment
 )
 
+portfolio_company_share_net_zero <- data_net_zero_commitments %>% 
+    filter(.data$name == "company_share_net_zero") %>% 
+    pull(.data$this_portfolio)
+peers_company_share_net_zero <- data_net_zero_commitments %>% 
+    filter(.data$name == "company_share_net_zero") %>% 
+    pull(.data$peergroup)
+
+portfolio_exposure_share_net_zero <- data_net_zero_commitments %>% 
+    filter(.data$name == "exposure_share_net_zero") %>% 
+    pull(.data$this_portfolio)
+peers_exposure_share_net_zero <- data_net_zero_commitments %>% 
+    filter(.data$name == "exposure_share_net_zero") %>% 
+    pull(.data$peergroup)
 ```
 
 ```{=latex}
 
 \begin{itemize}
-\item Anteil Portfolio-Unternehmen mit verifizierten Bekenntnissen zu Netto-Null und glaubwürdigen Zwischenzielen: \textbf{`r round(data_prep_net_zero_commitments %>% dplyr::filter(.data$portfolio_name == "this_portfolio") %>% dplyr::pull("share_net_zero") * 100, 1)` \%}
+\item Proportion of portfolio subject to public commitments to net zero and verified credible interim targets: \textbf{`r paste0(round(portfolio_exposure_share_net_zero * 100))` \% (Peers average: `r paste0(round(peers_exposure_share_net_zero * 100))` \%)}
 
-\item Durchschnittlicher Anteil der Unternehmen in Peer-Portfolios mit verifizierten Bekenntnissen zu Netto-Null und glaubwürdigen Zwischenzielen: \textbf{`r round(data_prep_net_zero_commitments %>% dplyr::filter(.data$portfolio_name == peer_group) %>% dplyr::pull("share_net_zero") * 100, 1)` \%}
+\item Share of companies in portfolio with verified commitments to net-zero and credible interim targets (as provided in the 2022 Swiss scorecard): \textbf{`r paste0(round(portfolio_company_share_net_zero * 100))` \% (Peers average: `r paste0(round(peers_company_share_net_zero * 100))` \%)}
 \end{itemize}
 ```
 

--- a/inst/extdata/PA2024CH_de_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_de_exec_summary/template.Rmd
@@ -9,6 +9,7 @@ always_allow_html: true
 params:
   survey_dir: NULL
   score_card_dir: NULL
+  analysis_inputs_dir: NULL
   language: EN
   investor_name: investor
   portfolio_name: portfolio

--- a/inst/extdata/PA2024CH_en_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2024CH_en_exec_summary/scorecard.Rmd
@@ -182,47 +182,61 @@ This score represents the estimated aggregate alignment of the PACTA sectors (ex
 
 ```{=latex}
 \begin{multicols}{2}
-%TODO: update depending on decision wrt SBTi
 \subsection{Verified Commitments to Net-Zero}
 
-Companies are increasingly making voluntary commitments to transition to net-zero and set interim targets. The effectiveness of such commitments depends on whether interim targets are credible, science-based, and transparent. The following information is based on information from \href{https://sciencebasedtargets.org/companies-taking-action}{SBTi}.
+Companies are increasingly committing voluntarily to transitioning to net zero and setting interim targets. The effectiveness of such commitments depends on whether interim emissions reduction targets applied are credible, science-based, transparent, and supported by credible action to cut emissions. The following information is based on information from SBTi \textbf{\href{https://sciencebasedtargets.org/companies-taking-action}{(link)}}.
 
 ```
 
 ```{r sbti_net_zero_commitments}
 fin_data_net_zero_targets <- readr::read_csv(
-  file.path(score_card_dir, "fin_data_net_zero_targets.csv"),
+  file.path(analysis_inputs_dir, "fin_data_net_zero_targets.csv"),
   col_types = readr::cols_only(
     isin = "c",
     asset_type = "c",
-    factset_entity_id = "c"
+    factset_entity_id = "c",
+    has_net_zero_commitment = "l"
   )
 )
 
-peer_group_share_net_zero <- readr::read_csv(
-  file.path(score_card_dir, "peer_group_share_net_zero.csv"),
+peers_net_zero_commitment <- readr::read_csv(
+  file.path(score_card_dir, "peers_sbti_results.csv"),
   col_types = readr::cols_only(
     investor_name = "c",
     portfolio_name = "c",
-    share_net_zero = "n"
+    company_share_net_zero = "d",
+    exposure_share_net_zero = "d"
   )
 )
 
-data_prep_net_zero_commitments <- prep_net_zero_commitments(
+data_net_zero_commitments <- prep_net_zero_commitments(
   total_portfolio = total_portfolio,
   peer_group = peer_group,
-  net_zero_targets = fin_data_net_zero_targets,
-  peer_group_share_net_zero = peer_group_share_net_zero
+  fin_data_net_zero_targets = fin_data_net_zero_targets,
+  peers_net_zero_commitment = peers_net_zero_commitment
 )
 
+portfolio_company_share_net_zero <- data_net_zero_commitments %>% 
+    filter(.data$name == "company_share_net_zero") %>% 
+    pull(.data$this_portfolio)
+peers_company_share_net_zero <- data_net_zero_commitments %>% 
+    filter(.data$name == "company_share_net_zero") %>% 
+    pull(.data$peergroup)
+
+portfolio_exposure_share_net_zero <- data_net_zero_commitments %>% 
+    filter(.data$name == "exposure_share_net_zero") %>% 
+    pull(.data$this_portfolio)
+peers_exposure_share_net_zero <- data_net_zero_commitments %>% 
+    filter(.data$name == "exposure_share_net_zero") %>% 
+    pull(.data$peergroup)
 ```
 
 ```{=latex}
 
 \begin{itemize}
-\item Share of companies in portfolio with verified commitments to net-zero and credible near term targets: \textbf{`r round(data_prep_net_zero_commitments %>% dplyr::filter(.data$portfolio_name == "this_portfolio") %>% dplyr::pull("share_net_zero") * 100, 1)` \%}
+\item Proportion of portfolio subject to public commitments to net zero and verified credible interim targets: \textbf{`r paste0(round(portfolio_exposure_share_net_zero * 100))` \% (Peers average: `r paste0(round(peers_exposure_share_net_zero * 100))` \%)}
 
-\item Average share of companies in peer portfolios with verified commitments to net-zero and credible interim targets: \textbf{`r round(data_prep_net_zero_commitments %>% dplyr::filter(.data$portfolio_name == peer_group) %>% dplyr::pull("share_net_zero") * 100, 1)` \%}
+\item Share of companies in portfolio with verified commitments to net-zero and credible interim targets (as provided in the 2022 Swiss scorecard): \textbf{`r paste0(round(portfolio_company_share_net_zero * 100))` \% (Peers average: `r paste0(round(peers_company_share_net_zero * 100))` \%)}
 \end{itemize}
 ```
 

--- a/inst/extdata/PA2024CH_en_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_en_exec_summary/template.Rmd
@@ -9,6 +9,7 @@ always_allow_html: true
 params:
   survey_dir: NULL
   score_card_dir: NULL
+  analysis_inputs_dir: NULL
   language: EN
   investor_name: investor
   portfolio_name: portfolio

--- a/inst/extdata/PA2024CH_fr_exec_summary/scorecard.Rmd
+++ b/inst/extdata/PA2024CH_fr_exec_summary/scorecard.Rmd
@@ -184,46 +184,59 @@ Ce score représente l'alignement agrégé estimé des secteurs PACTA (hors cime
 
 \subsection{Engagements vérifiés en faveur du net zéro}
 
-Un nombre croissant d’entreprises s’engage volontairement à atteindre zéro émissions nettes et formulent des objectifs intermédiaires pour y parvenir. L’efficacité de ces engagements dépend de la crédibilité, du fondement scientifique et de la transparence des objectifs intermédiaires. Les informations suivantes sont basées sur les informations émanant de SBTi \textbf{\href{https://sciencebasedtargets.org/companies-taking-action}{(lien)}}.
+Companies are increasingly committing voluntarily to transitioning to net zero and setting interim targets. The effectiveness of such commitments depends on whether interim emissions reduction targets applied are credible, science-based, transparent, and supported by credible action to cut emissions. The following information is based on information from SBTi \textbf{\href{https://sciencebasedtargets.org/companies-taking-action}{(link)}}.
 
 ```
 
 ```{r sbti_net_zero_commitments}
 fin_data_net_zero_targets <- readr::read_csv(
-  file.path(score_card_dir, "fin_data_net_zero_targets.csv"),
+  file.path(analysis_inputs_dir, "fin_data_net_zero_targets.csv"),
   col_types = readr::cols_only(
     isin = "c",
     asset_type = "c",
-    factset_entity_id = "c"
+    factset_entity_id = "c",
+    has_net_zero_commitment = "l"
   )
 )
 
-peer_group_share_net_zero <- readr::read_csv(
-  file.path(score_card_dir, "peer_group_share_net_zero.csv"),
+peers_net_zero_commitment <- readr::read_csv(
+  file.path(score_card_dir, "peers_sbti_results.csv"),
   col_types = readr::cols_only(
     investor_name = "c",
     portfolio_name = "c",
-    share_net_zero = "n"
+    company_share_net_zero = "d",
+    exposure_share_net_zero = "d"
   )
 )
 
-data_prep_net_zero_commitments <- prep_net_zero_commitments(
+data_net_zero_commitments <- prep_net_zero_commitments(
   total_portfolio = total_portfolio,
   peer_group = peer_group,
-  net_zero_targets = fin_data_net_zero_targets,
-  peer_group_share_net_zero = peer_group_share_net_zero
+  fin_data_net_zero_targets = fin_data_net_zero_targets,
+  peers_net_zero_commitment = peers_net_zero_commitment
 )
 
+portfolio_company_share_net_zero <- data_net_zero_commitments %>% 
+    filter(.data$name == "company_share_net_zero") %>% 
+    pull(.data$this_portfolio)
+peers_company_share_net_zero <- data_net_zero_commitments %>% 
+    filter(.data$name == "company_share_net_zero") %>% 
+    pull(.data$peergroup)
+
+portfolio_exposure_share_net_zero <- data_net_zero_commitments %>% 
+    filter(.data$name == "exposure_share_net_zero") %>% 
+    pull(.data$this_portfolio)
+peers_exposure_share_net_zero <- data_net_zero_commitments %>% 
+    filter(.data$name == "exposure_share_net_zero") %>% 
+    pull(.data$peergroup)
 ```
 
 ```{=latex}
 
 \begin{itemize}
+\item Proportion of portfolio subject to public commitments to net zero and verified credible interim targets: \textbf{`r paste0(round(portfolio_exposure_share_net_zero * 100))` \% (Peers average: `r paste0(round(peers_exposure_share_net_zero * 100))` \%)}
 
-\item Part des entreprises du portefeuille ayant pris des engagements vérifiés pour atteindre le \guillemetleft net zéro\guillemetright \ et pour la fixation d’objectifs intermédiaires crédibles: \textbf{`r round(data_prep_net_zero_commitments %>% dplyr::filter(.data$portfolio_name == "this_portfolio") %>% dplyr::pull("share_net_zero") * 100, 1)` \%}
-
-\item Part moyenne des entreprises dans les portefeuilles de pairs ayant des engagements vérifiés envers le net zéro et des objectifs intermédiaires crédibles: \textbf{`r round(data_prep_net_zero_commitments %>% dplyr::filter(.data$portfolio_name == peer_group) %>% dplyr::pull("share_net_zero") * 100, 1)` \%}
-
+\item Share of companies in portfolio with verified commitments to net-zero and credible interim targets (as provided in the 2022 Swiss scorecard): \textbf{`r paste0(round(portfolio_company_share_net_zero * 100))` \% (Peers average: `r paste0(round(peers_company_share_net_zero * 100))` \%)}
 \end{itemize}
 ```
 

--- a/inst/extdata/PA2024CH_fr_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_fr_exec_summary/template.Rmd
@@ -9,6 +9,7 @@ always_allow_html: true
 params:
   survey_dir: NULL
   score_card_dir: NULL
+  analysis_inputs_dir: NULL
   language: EN
   investor_name: investor
   portfolio_name: portfolio

--- a/man/render_executive_summary.Rd
+++ b/man/render_executive_summary.Rd
@@ -36,6 +36,8 @@ render_executive_summary(
 
 \item{score_card_dir}{Character single, valid filepath to a directory that contains score card files for the user}
 
+\item{analysis_inputs_dir}{Character single, valid filepath to a PACTA analysis results directory that contains the SBTi data merged with financial data in the COP case}
+
 \item{file_name}{Character single, valid filename of the Rmd template file, e.g. "template.Rmd"}
 
 \item{investor_name}{Character single string specifying the investor name}
@@ -53,8 +55,6 @@ render_executive_summary(
 \item{currency_exchange_value}{Numeric single numeric value specifying the exchange rate from USD into the desired display currency, e.g. \code{1.03}}
 
 \item{log_dir}{Character single, valid filepath to a directory that will contain the log file}
-
-\item{analysis_inputs_dir:}{Character single, valid filepath to a PACTA analysis results directory that contains the SBTi data merged with financial data in the COP case}
 }
 \value{
 a pdf document written to output_dir

--- a/man/render_executive_summary.Rd
+++ b/man/render_executive_summary.Rd
@@ -11,6 +11,7 @@ render_executive_summary(
   exec_summary_dir,
   survey_dir,
   score_card_dir,
+  analysis_inputs_dir,
   file_name = "template.Rmd",
   investor_name,
   portfolio_name,
@@ -52,6 +53,8 @@ render_executive_summary(
 \item{currency_exchange_value}{Numeric single numeric value specifying the exchange rate from USD into the desired display currency, e.g. \code{1.03}}
 
 \item{log_dir}{Character single, valid filepath to a directory that will contain the log file}
+
+\item{analysis_inputs_dir:}{Character single, valid filepath to a PACTA analysis results directory that contains the SBTi data merged with financial data in the COP case}
 }
 \value{
 a pdf document written to output_dir


### PR DESCRIPTION
This PR builds on code implemented in #340, making it fully functional together with https://github.com/RMI-PACTA/workflow.transition.monitor/pull/331. 

NOTE: Also, for the PR to run without errors the `pacta-data` folder needs to contain `fin_data_net_zero_targets.csv` and has to use the most recent version of the testing user_data (https://github.com/RMI-PACTA/user_results/pull/24/files/f75b9955f640a74124003e524a6a5789d9b616b8..355ef24f21422238c88be9ad6ff571ef2d5e56db).