### PR TITLE
bug: allow `cement` as an input sector to `plot_scores`

### DIFF
--- a/R/plot_scores.R
+++ b/R/plot_scores.R
@@ -227,7 +227,7 @@ check_data_scores <- function(data, env) {
   abort_if_invalid_values(
     data,
     "sector",
-    c(NA, "power", "automotive", "coal", "oil", "gas", "aviation", "steel")
+    c(NA, "power", "automotive", "coal", "oil", "gas", "aviation", "steel", "cement")
   )
   abort_if_invalid_values(data, "score", c("A+", "A", "B", "C", "D", "E"))
 }


### PR DESCRIPTION
@MonikaFu unless there is a specific reason not to? 

Relates to https://github.com/RMI-PACTA/workflow.transition.monitor/pull/333

and in particular
https://github.com/RMI-PACTA/workflow.transition.monitor/pull/333#issuecomment-2205864640