### PR TITLE
Use a different font to render `eszett` character

### DIFF
--- a/inst/extdata/PA2024CH_de_exec_summary/preamble.tex
+++ b/inst/extdata/PA2024CH_de_exec_summary/preamble.tex
@@ -5,6 +5,7 @@
 \usepackage{multicol}
 \usepackage{hyperref}
 \usepackage{textcomp}
+\usepackage{fouriernc}
 
 % \usepackage[default]{opensans}
 \usepackage[T1]{fontenc}
@@ -50,7 +51,6 @@ headheight=0.0in
 %     ]
 
 % \setmainfont{OpenSans}
-\renewcommand{\familydefault}{\sfdefault}
 
 \NewDocumentCommand \verticalAlignImage {}{
   \strut\vspace*{-\baselineskip}\newline

--- a/inst/extdata/PA2024CH_en_exec_summary/preamble.tex
+++ b/inst/extdata/PA2024CH_en_exec_summary/preamble.tex
@@ -5,7 +5,6 @@
 \usepackage{multicol}
 \usepackage{hyperref}
 \usepackage{textcomp}
-\usepackage{fouriernc}
 
 % \usepackage[default]{opensans}
 \usepackage[T1]{fontenc}
@@ -51,6 +50,7 @@ headheight=0.0in
 %     ]
 
 % \setmainfont{OpenSans}
+\renewcommand{\familydefault}{\sfdefault}
 
 \NewDocumentCommand \verticalAlignImage {}{
   \strut\vspace*{-\baselineskip}\newline

--- a/inst/extdata/PA2024CH_en_exec_summary/preamble.tex
+++ b/inst/extdata/PA2024CH_en_exec_summary/preamble.tex
@@ -5,6 +5,7 @@
 \usepackage{multicol}
 \usepackage{hyperref}
 \usepackage{textcomp}
+\usepackage{fouriernc}
 
 % \usepackage[default]{opensans}
 \usepackage[T1]{fontenc}
@@ -50,7 +51,6 @@ headheight=0.0in
 %     ]
 
 % \setmainfont{OpenSans}
-\renewcommand{\familydefault}{\sfdefault}
 
 \NewDocumentCommand \verticalAlignImage {}{
   \strut\vspace*{-\baselineskip}\newline


### PR DESCRIPTION
This is just a test to see if the advice given in https://dev.azure.com/RMI-PACTA/2DegreesInvesting/_workitems/edit/12039
works. 