### PR TITLE
make all footnotes same size

### DIFF
--- a/inst/extdata/PA2024CH_de_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_de_exec_summary/template.Rmd
@@ -190,7 +190,6 @@ tryCatch(
 
 \begin{esbox}{Ist-Zustand (PACTA-Sektoren)}[\exposureImage]
 
-%FIXME: make footnote
 \textbf{Exposition* gegenüber klimarelevanten Sektoren und Technologien in \% des verwalteten Vermögens}
 
 Die Grafik zeigt die Exposition gegenüber Unternehmen mit Produktionsstätten in den von PACTA erfassten Teilen der Wertschöpfungskette. Die Exposition gegenüber fossilen Brennstoffen (Förderung von Kohle, Öl, Gas) wird aggregiert sowie zu Vergleichszwecken zusätzlich einzeln ausgewiesen und mit Peers und einem Index verglichen.
@@ -447,10 +446,9 @@ tryCatch(
 ```
 
 ```{=latex}
-%FIXME: footnote
-* Erneuerbare Energien: umfasst Solar- und Windenergie, ohne Wasser- und Kernkraft
+\raggedright\footnotesize{* Erneuerbare Energien: umfasst Solar- und Windenergie, ohne Wasser- und Kernkraft}
 
-** Automobilindustrie: umfasst leichte Fahrzeuge (eng. Light-duty vehicles, LDV)
+\raggedright\footnotesize{** Automobilindustrie: umfasst leichte Fahrzeuge (eng. Light-duty vehicles, LDV)}
 
 \end{esbox}
 

--- a/inst/extdata/PA2024CH_en_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_en_exec_summary/template.Rmd
@@ -188,7 +188,6 @@ tryCatch(
 
 \begin{esbox}{Current state (PACTA sectors)}[\exposureImage]
 
-%FIXME: make footnote
 \textbf{Exposure* to climate-relevant sectors \& technologies as \% of AUM}
 
 The chart provides information on the exposure to companies with physical assets in the parts of the value chain covered by PACTA. Fossil fuels (extraction) is shown aggregated as well as disaggregated for peer- and index-comparison.
@@ -235,6 +234,7 @@ tryCatch(
 
 ```{=latex}
 \raggedright\footnotesize{* Exposure to companies with main activity in PACTA sectors}
+
 \raggedright\footnotesize{** ‘Low-carbon’ technologies: renewables and hydro for power and electric for automotive. ‘High-carbon’ technologies:  oil, gas and coal for power, hybrid, ICE for automotive.}
 
 \end{esbox}
@@ -439,10 +439,12 @@ tryCatch(
 ```
 
 ```{=latex}
-%FIXME: footnote
-* Renewables: include solar and wind power, exclude hydro and nuclear
+\raggedright\footnotesize{* Renewables: include solar and wind power, exclude hydro and nuclear}
 
-** Automotive: includes light-duty vehicles (LDV)
+\raggedright\footnotesize{** Automotive: includes light-duty vehicles (LDV)}
+
+
+
 
 \end{esbox}
 

--- a/inst/extdata/PA2024CH_fr_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_fr_exec_summary/template.Rmd
@@ -189,7 +189,6 @@ tryCatch(
 
 \begin{esbox}{Etat actuel (secteurs PACTA)}[\exposureImage]
 
-%FIXME: make footnote
 \textbf{Exposition* aux secteurs et technologies concernés par le climat en \% de l'actif sous gestion}
 
 Le graphique fournit des information sur l'exposition aux entreprises avec des actifs physiques dans les parties de la chaîne de valeur couvert par PACTA. Les combustibles fossiles (extraction de charbon, pétrole, gaz) sont présentés de manière agrégée et désagrégée à des fins de comparaison avec les pairs (institutions de prévoyance, les assurances, les banques ou les gestionnaires d'actif) et un indice.
@@ -238,7 +237,7 @@ tryCatch(
 
 \raggedright\footnotesize{* Exposition aux entreprises dont le principal secteur d'activité est couvert par PACTA}
 
-** Technologies \guillemetleft à faible émission de CO\textsubscript{2}\guillemetright \ (low-carbon): énergies renouvelables et l'hydroélectricité pour l'électricité et énergie électrique pour l'automobile. Technologies \guillemetleft à forte émission de carbone\guillemetright \ (high-carbon): charbon, pétrole, gaz 
+\raggedright\footnotesize{** Technologies \guillemetleft à faible émission de CO\textsubscript{2}\guillemetright \ (low-carbon): énergies renouvelables et l'hydroélectricité pour l'électricité et énergie électrique pour l'automobile. Technologies \guillemetleft à forte émission de carbone\guillemetright \ (high-carbon): charbon, pétrole, gaz}
 \end{esbox}
 
 \begin{esbox}{État actuel et futur (secteur de l'électricité)}[\alignmentImage
@@ -443,10 +442,9 @@ tryCatch(
 ```
 
 ```{=latex}
-%FIXME: footnote
-* Energies renouvelables: inclut l'énergie solaire et éolienne, mais exclut l'hydroélectricité et le nucléaire
+\raggedright\footnotesize{* Energies renouvelables: inclut l'énergie solaire et éolienne, mais exclut l'hydroélectricité et le nucléaire}
 
-** Automobile: comprend les véhicules légers (LDV)
+\raggedright\footnotesize{** Automobile: comprend les véhicules légers (LDV)}
 
 \end{esbox}
 


### PR DESCRIPTION
I couldn't figure out how to actually convert these into Footnotes, since the first of the footnotes are stemming from content in the text body itself, while the second footnote comes from data that is within a plot (i don't think LaTeX can even pick up notes from that aahah)

In this PR, I've simply tried to make all footnotes the same size. Will test with EN on CI first, and then port changes to other languages if it works.

Maybe closes #251 

Partially addresses https://dev.azure.com/RMI-PACTA/2DegreesInvesting/_workitems/edit/12058