### PR TITLE
Annex exclusion dart plot doesn't explode across the page

### DIFF
--- a/inst/extdata/PA2024CH_de_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_de_exec_summary/template.Rmd
@@ -543,7 +543,7 @@ Die folgende Grafik zeigt die Anforderungen in Bezug auf den Gesamtscore zur Kli
 
 \begin{minipage}[t]{0.3\textwidth}
 \verticalAlignImage
-\includegraphics{chart_sample_dart_chart_full}
+\includegraphics[width=\textwidth]{chart_sample_dart_chart_full}
 
 \end{minipage}%
 \hspace{0.05\textwidth}

--- a/inst/extdata/PA2024CH_en_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_en_exec_summary/template.Rmd
@@ -539,7 +539,7 @@ The chart below visualizes the specifications of the aggregated alignment score 
 
 \begin{minipage}[t]{0.3\textwidth}
 \verticalAlignImage
-\includegraphics{chart_sample_dart_chart_full}
+\includegraphics[width=\textwidth]{chart_sample_dart_chart_full}
 
 \end{minipage}%
 \hspace{0.05\textwidth}

--- a/inst/extdata/PA2024CH_fr_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_fr_exec_summary/template.Rmd
@@ -539,7 +539,7 @@ Le graphique ci-dessous présente les spécifications du score d'alignement agr�
 
 \begin{minipage}[t]{0.3\textwidth}
 \verticalAlignImage
-\includegraphics{chart_sample_dart_chart_full}
+\includegraphics[width=\textwidth]{chart_sample_dart_chart_full}
 
 \end{minipage}%
 \hspace{0.05\textwidth}


### PR DESCRIPTION
This plot was exploding off the screen:
<img width="508" alt="Screenshot 2024-11-01 at 15 18 38" src="https://github.com/user-attachments/assets/ea820e3e-3c72-412f-a9b0-3388aa5f92b7">

Fixed in all languages