### PR TITLE
remove unnecessary page breaks

### DIFF
--- a/inst/extdata/PA2024CH_de_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_de_exec_summary/template.Rmd
@@ -184,8 +184,6 @@ tryCatch(
 
 \end{esbox}
 
-\newpage
-
 \section{Ergebnisse Aktien- und Unternehmensanleiheportfolios}
 
 \begin{esbox}{Ist-Zustand (PACTA-Sektoren)}[\exposureImage]
@@ -377,10 +375,6 @@ tryCatch(
 
 ```{=latex}
 \end{esbox}
-
-\newpage
-
-\section{Ergebnisse von Aktien- und Unternehmensanleiheportfolios}
 
 \begin{esbox}{Transition}[\alignmentImage \exposureImage]
 

--- a/inst/extdata/PA2024CH_en_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_en_exec_summary/template.Rmd
@@ -182,8 +182,6 @@ tryCatch(
 
 \end{esbox}
 
-\newpage
-
 \section{Equity \& Bonds Results}
 
 \begin{esbox}{Current state (PACTA sectors)}[\exposureImage]
@@ -373,10 +371,6 @@ tryCatch(
 
 ```{=latex}
 \end{esbox}
-
-\newpage
-
-\section{Equity \& Bonds Results}
 
 \begin{esbox}{Transition}[\alignmentImage \exposureImage]
 

--- a/inst/extdata/PA2024CH_fr_exec_summary/template.Rmd
+++ b/inst/extdata/PA2024CH_fr_exec_summary/template.Rmd
@@ -183,8 +183,6 @@ tryCatch(
 
 \end{esbox}
 
-\newpage
-
 \section{Résultats pour les actions et obligations d’entreprise}
 
 \begin{esbox}{Etat actuel (secteurs PACTA)}[\exposureImage]
@@ -375,10 +373,6 @@ tryCatch(
 
 ```{=latex}
 \end{esbox}
-
-\newpage
-
-\section{Résultats pour les actions et obligations d’entreprise}
 
 \begin{esbox}{Transition}[\alignmentImage \exposureImage]
 


### PR DESCRIPTION
After adjusting the margins, it was noticed that many plots appeared on their own single page. 
To combine more plots on a single page, we elected to remove several page breaks. 

Supersedes https://github.com/RMI-PACTA/pacta.executive.summary/pull/391

FYI @hodie and @MonikaFu 